### PR TITLE
Package opensea-js with just built files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "opensea-js",
   "version": "0.5.0-rc13",
   "description": "JavaScript SDK for the OpenSea marketplace. Let users buy or sell crypto collectibles and other cryptogoods, all on your own site!",
+  "files": [
+    "lib",
+    "webpack.config.js"
+  ],
   "main": "lib/index.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha test/*.ts --require ts-node/register --timeout 15000",


### PR DESCRIPTION
This just tags `npm pack` to include only distribution files, ignoring the generated documentation folders and the `src` folder.

Before:
```
npm notice package size:  340.1 kB                                
npm notice unpacked size: 2.4 MB  
```

After: 
```
npm notice package size:  99.1 kB                                 
npm notice unpacked size: 593.8 kB       
```

## Test Plan

1. `npm pack` the repo.
2. `cd` into `package` folder from unzipping archive.
3. `yarn link` package
4. `yarn link` some other package that depends on `opensea-js`
5. Ensure other package builds successfully.