### PR TITLE
Fix order validity check

### DIFF
--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -1275,7 +1275,7 @@ export class OpenSeaPort {
 
     this.logger(`Gas estimate for ${order.side == OrderSide.Sell ? "sell" : "buy"} order: ${gas}`)
 
-    return gas != null && gas > 0
+    return gas != null && gas != undefined && gas > 0
   }
 
   /**


### PR DESCRIPTION
I've found an edge case where the gas estimate for the sell order is returned as undefined if execution reverts. This should return `false`.