### PR TITLE
ethereumjs-abi url

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://docs.opensea.io/v1.0/reference",
   "dependencies": {
     "bignumber.js": "^4.1.0",
-    "ethereumjs-abi": "git+https://github.com/ProjectWyvern/ethereumjs-abi.git",
+    "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^5.2.0",
     "fbemitter": "^2.1.1",
     "isomorphic-unfetch": "^2.1.1",


### PR DESCRIPTION
ethereumjs-abi github url is no longer valid