### PR TITLE
Remove signature setting for counter orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "1.2.7",
+  "version": "1.2.8-beta.1.6.0",
   "description": "JavaScript SDK for the OpenSea marketplace. Let users buy or sell crypto collectibles and other cryptogoods, all on your own site!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/__tests__/seaport/orders.ts
+++ b/src/__tests__/seaport/orders.ts
@@ -32,12 +32,13 @@ import {
 import {
   ALEX_ADDRESS,
   ALEX_ADDRESS_2,
-  CATS_IN_MECHS_ID,
   CK_ADDRESS,
   CK_RINKEBY_ADDRESS,
   CK_RINKEBY_TOKEN_ID,
   CK_TOKEN_ID,
   CRYPTOFLOWERS_CONTRACT_ADDRESS_WITH_BUYER_FEE,
+  CRYPTOVOXELS_WEARABLE_2_ID,
+  CRYPTOVOXELS_WEARABLE_ADDRESS,
   DEVIN_ADDRESS,
   DIGITAL_ART_CHAIN_ADDRESS,
   DIGITAL_ART_CHAIN_TOKEN_ID,
@@ -754,8 +755,8 @@ suite("seaport: orders", () => {
     const takerAddress = ALEX_ADDRESS_2;
     const amountInEth = 2;
 
-    const tokenId = CATS_IN_MECHS_ID;
-    const tokenAddress = ENJIN_ADDRESS;
+    const tokenId = CRYPTOVOXELS_WEARABLE_2_ID;
+    const tokenAddress = CRYPTOVOXELS_WEARABLE_ADDRESS;
 
     const asset = await client.api.getAsset({ tokenAddress, tokenId });
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -910,6 +910,7 @@ export function getOrderHash(order: UnhashedOrder) {
 
 /**
  * Assign an order and a new matching order to their buy/sell sides
+ * Note: The new matching order is generated on the fly and not from the database
  * @param order Original order
  * @param matchingOrder The result of _makeMatchingOrder
  */
@@ -921,21 +922,23 @@ export function assignOrdersToSides(
 
   let buy: Order;
   let sell: Order;
+  // Since wyvern does not validate signature of sender, we can send
+  // null signature data to save on space, and thus gas.
   if (!isSellOrder) {
     buy = order;
     sell = {
       ...matchingOrder,
-      v: buy.v,
-      r: buy.r,
-      s: buy.s,
+      v: 0,
+      r: NULL_BLOCK_HASH,
+      s: NULL_BLOCK_HASH,
     };
   } else {
     sell = order;
     buy = {
       ...matchingOrder,
-      v: sell.v,
-      r: sell.r,
-      s: sell.s,
+      v: 0,
+      r: NULL_BLOCK_HASH,
+      s: NULL_BLOCK_HASH,
     };
   }
 


### PR DESCRIPTION
Summary
- Implementing a minor gas savings for all eth erc721 transactions that occur through wyvern, excluding english auctions.

What is the fix:
- Removing passing signature data for counterorders, since they do not get checked by wyvern anyway

Impact:
- ~1,600 gas per "buy now" or "accept offer"

Source:
- https://gist.github.com/jschiarizzi/31be9f4ecd66715e4458f007f01b8d13