### PR TITLE
Fix sign typed data to be compatible for more providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "2.0.0",
+  "version": "2.0.1-beta.0",
   "description": "JavaScript SDK for the OpenSea marketplace. Let users buy or sell crypto collectibles and other cryptogoods, all on your own site!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "2.0.1-beta.1",
+  "version": "2.0.1",
   "description": "JavaScript SDK for the OpenSea marketplace. Let users buy or sell crypto collectibles and other cryptogoods, all on your own site!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "2.0.1-beta.0",
+  "version": "2.0.1-beta.1",
   "description": "JavaScript SDK for the OpenSea marketplace. Let users buy or sell crypto collectibles and other cryptogoods, all on your own site!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/seaport.ts
+++ b/src/seaport.ts
@@ -4326,7 +4326,9 @@ export class OpenSeaPort {
         salt: order.salt.toString(),
       };
 
-      const message = JSON.stringify({
+      // We don't JSON.stringify as certain wallet providers sanitize this data
+      // https://github.com/coinbase/coinbase-wallet-sdk/issues/60
+      const message = {
         types: EIP_712_ORDER_TYPES,
         domain: {
           name: EIP_712_WYVERN_DOMAIN_NAME,
@@ -4336,7 +4338,7 @@ export class OpenSeaPort {
         },
         primaryType: "Order",
         message: { ...orderForSigning, nonce: signerOrderNonce.toNumber() },
-      });
+      };
 
       const ecSignature = await signTypedDataAsync(
         this.web3,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -550,18 +550,37 @@ export async function signTypedDataAsync(
   message: object,
   signerAddress: string
 ): Promise<ECSignature> {
-  const signature = await promisify<Web3.JSONRPCResponsePayload>((c) =>
-    web3.currentProvider.sendAsync(
-      {
-        method: "eth_signTypedData",
-        params: [signerAddress, message],
-        from: signerAddress,
-        id: new Date().getTime(),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any,
-      c
-    )
-  );
+  let signature: Web3.JSONRPCResponsePayload;
+  try {
+    // Using sign typed data V4 works with a stringified message, used by browser providers i.e. Metamask
+    signature = await promisify<Web3.JSONRPCResponsePayload>((c) =>
+      web3.currentProvider.sendAsync(
+        {
+          method: "eth_signTypedData_v4",
+          params: [signerAddress, JSON.stringify(message)],
+          from: signerAddress,
+          id: new Date().getTime(),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        c
+      )
+    );
+  } catch {
+    // Fallback to normal sign typed data for node providers, without using stringified message
+    // https://github.com/coinbase/coinbase-wallet-sdk/issues/60
+    signature = await promisify<Web3.JSONRPCResponsePayload>((c) =>
+      web3.currentProvider.sendAsync(
+        {
+          method: "eth_signTypedData",
+          params: [signerAddress, message],
+          from: signerAddress,
+          id: new Date().getTime(),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        c
+      )
+    );
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const error = (signature as any).error;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -547,7 +547,7 @@ export async function personalSignAsync(
  */
 export async function signTypedDataAsync(
   web3: Web3,
-  message: string,
+  message: object,
   signerAddress: string
 ): Promise<ECSignature> {
   const signature = await promisify<Web3.JSONRPCResponsePayload>((c) =>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -553,7 +553,7 @@ export async function signTypedDataAsync(
   const signature = await promisify<Web3.JSONRPCResponsePayload>((c) =>
     web3.currentProvider.sendAsync(
       {
-        method: "eth_signTypedData_v4",
+        method: "eth_signTypedData",
         params: [signerAddress, message],
         from: signerAddress,
         id: new Date().getTime(),


### PR DESCRIPTION
Sign typed data v2,3,4 are not supported by a number of providers. Changing to just use regular signTypedData. Also removing JSON.stringify as some wallet providers sanitize the message