### PR TITLE
Remove search field from Asset & Bundle API lookups

### DIFF
--- a/src/__tests__/api/api.ts
+++ b/src/__tests__/api/api.ts
@@ -147,7 +147,7 @@ suite("api", () => {
   });
 
   test("Rinkeby API orders have correct OpenSea url", async () => {
-    const order = await rinkebyApi.getOrder({});
+    const order = await rinkebyApi.getOrder({ side: OrderSide.Buy });
     if (!order.asset) {
       return;
     }
@@ -156,7 +156,7 @@ suite("api", () => {
   });
 
   test("Mainnet API orders have correct OpenSea url", async () => {
-    const order = await mainApi.getOrder({});
+    const order = await mainApi.getOrder({ side: OrderSide.Sell });
     if (!order.asset) {
       return;
     }
@@ -183,7 +183,7 @@ suite("api", () => {
   if (ORDERBOOK_VERSION > 0) {
     test("API orderbook paginates", async () => {
       const { orders, count } = await apiToTest.getOrders();
-      const pagination = await apiToTest.getOrders({}, 2);
+      const pagination = await apiToTest.getOrders({ side: OrderSide.Buy }, 2);
       assert.equal(pagination.orders.length, apiToTest.pageSize);
       assert.notDeepEqual(pagination.orders[0], orders[0]);
       assert.equal(pagination.count, count);
@@ -194,13 +194,17 @@ suite("api", () => {
     const forKitty = await apiToTest.getOrders({
       asset_contract_address: CK_RINKEBY_ADDRESS,
       token_id: CK_RINKEBY_TOKEN_ID,
+      side: OrderSide.Buy,
     });
     assert.isArray(forKitty.orders);
   });
 
   // Temp skip due to migration
   test.skip("API fetches orders for asset owner", async () => {
-    const forOwner = await apiToTest.getOrders({ owner: ALEX_ADDRESS });
+    const forOwner = await apiToTest.getOrders({
+      owner: ALEX_ADDRESS,
+      side: OrderSide.Buy,
+    });
     assert.isAbove(forOwner.orders.length, 0);
     assert.isAbove(forOwner.count, 0);
     const owners = forOwner.orders.map(
@@ -226,7 +230,10 @@ suite("api", () => {
   });
 
   test("API excludes cancelledOrFinalized and markedInvalid orders", async () => {
-    const { orders } = await apiToTest.getOrders({ limit: 50 });
+    const { orders } = await apiToTest.getOrders({
+      side: OrderSide.Sell,
+      limit: 50,
+    });
     const finishedOrders = orders.filter((o) => o.cancelledOrFinalized);
     assert.isEmpty(finishedOrders);
     const invalidOrders = orders.filter((o) => o.markedInvalid);
@@ -277,6 +284,7 @@ suite("api", () => {
     const res = await apiToTest.getOrders({
       // Get an old order to make sure listing time is too early
       listed_before: Math.round(Date.now() / 1000 - 3600),
+      side: OrderSide.Sell,
     });
     const order = res.orders[0];
     assert.isNotNull(order);

--- a/src/__tests__/api/api.ts
+++ b/src/__tests__/api/api.ts
@@ -151,7 +151,7 @@ suite("api", () => {
     if (!order.asset) {
       return;
     }
-    const url = `https://testnets.opensea.io/assets/${order.asset.assetContract.address}/${order.asset.tokenId}`;
+    const url = `https://testnets.opensea.io/assets/rinkeby/${order.asset.assetContract.address}/${order.asset.tokenId}`;
     assert.equal(order.asset.openseaLink, url);
   });
 
@@ -160,7 +160,7 @@ suite("api", () => {
     if (!order.asset) {
       return;
     }
-    const url = `https://opensea.io/assets/${order.asset.assetContract.address}/${order.asset.tokenId}`;
+    const url = `https://opensea.io/assets/ethereum/${order.asset.assetContract.address}/${order.asset.tokenId}`;
     assert.equal(order.asset.openseaLink, url);
   });
 

--- a/src/__tests__/seaport/orders.ts
+++ b/src/__tests__/seaport/orders.ts
@@ -955,6 +955,7 @@ suite("seaport: orders", () => {
   test.skip("orderToJSON computes correct current price for Dutch auctions", async () => {
     const { orders } = await client.api.getOrders({
       sale_kind: SaleKind.DutchAuction,
+      side: OrderSide.Sell,
     });
     assert.equal(orders.length, client.api.pageSize);
     orders.map((order) => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -23,6 +23,7 @@ import {
   OrderbookResponse,
   OrderJSON,
   OrderQuery,
+  OrderSide,
 } from "./types";
 import {
   assetBundleFromJSON,
@@ -171,7 +172,7 @@ export class OpenSeaAPI {
    * `limit` and `offset` attributes from OrderQuery
    */
   public async getOrders(
-    query: OrderQuery = {},
+    query: OrderQuery = { side: OrderSide.Sell },
     page = 1
   ): Promise<{ orders: Order[]; count: number }> {
     const result = await this.get(`${ORDERBOOK_PATH}/orders/`, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -518,7 +518,6 @@ export interface OpenSeaAssetBundleQuery
   owner?: string;
   offset?: number;
   limit?: number;
-  search?: string;
 }
 
 /**
@@ -693,7 +692,6 @@ export interface OpenSeaAssetQuery {
   owner?: string;
   asset_contract_address?: string;
   token_ids?: Array<number | string>;
-  search?: string;
   order_by?: string;
   order_direction?: string;
   limit?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -669,6 +669,7 @@ export type RawWyvernOrderJSON = Omit<
 export interface OrderQuery extends Partial<OrderJSON> {
   owner?: string;
   sale_kind?: SaleKind;
+  side: OrderSide;
   asset_contract_address?: string;
   payment_token_address?: string;
   is_english?: boolean;


### PR DESCRIPTION
We don't support search as a query param in the Asset & Bundle endpoints anymore