### PR TITLE
Update order assets to use lazy mint adapter address in place of shared storefront address

### DIFF
--- a/src/__tests__/sdk/misc.ts
+++ b/src/__tests__/sdk/misc.ts
@@ -5,11 +5,15 @@ import {
   CK_ADDRESS,
   MAINNET_PROVIDER_URL,
   MAX_UINT_256,
+  SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS,
+  SHARED_STORE_FRONT_ADDRESS_MAINNET,
+  SHARED_STORE_FRONT_ADDRESS_RINKEBY,
 } from "../../constants";
 import { ERC721 } from "../../contracts";
 import { OpenSeaSDK } from "../../index";
 import { Network } from "../../types";
 import {
+  getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress,
   getNonCompliantApprovalAddress,
   isContractAddress,
 } from "../../utils/utils";
@@ -99,5 +103,45 @@ suite("SDK: misc", () => {
     );
     assert.equal(acccountOneIsContractAddress, true);
     assert.equal(acccountTwoIsContractAddress, false);
+  });
+
+  test("Checks that a non-shared storefront address is not remapped", async () => {
+    const address = DAN_DAPPER_ADDRESS;
+    assert.equal(
+      getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
+        address
+      ),
+      address
+    );
+  });
+
+  test("Checks that shared storefront addresses are remapped to lazy mint adapter address", async () => {
+    assert.equal(
+      getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
+        SHARED_STORE_FRONT_ADDRESS_RINKEBY
+      ),
+      SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
+    );
+    assert.equal(
+      getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
+        SHARED_STORE_FRONT_ADDRESS_MAINNET
+      ),
+      SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
+    );
+  });
+
+  test("Checks that upper case shared storefront addresses are remapped to lazy mint adapter address", async () => {
+    assert.equal(
+      getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
+        SHARED_STORE_FRONT_ADDRESS_MAINNET.toUpperCase()
+      ),
+      SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
+    );
+    assert.equal(
+      getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
+        SHARED_STORE_FRONT_ADDRESS_MAINNET.toUpperCase()
+      ),
+      SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
+    );
   });
 });

--- a/src/__tests__/sdk/misc.ts
+++ b/src/__tests__/sdk/misc.ts
@@ -133,7 +133,7 @@ suite("SDK: misc", () => {
   test("Checks that upper case shared storefront addresses are remapped to lazy mint adapter address", async () => {
     assert.equal(
       getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-        SHARED_STORE_FRONT_ADDRESS_MAINNET.toUpperCase()
+        SHARED_STORE_FRONT_ADDRESS_RINKEBY.toUpperCase()
       ),
       SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
     );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,7 +12,7 @@ export const OPENSEA_FEE_RECIPIENT =
 export const INVERSE_BASIS_POINT = 10_000; // 100 basis points per 1%
 export const MAX_UINT_256 = WyvernProtocol.MAX_UINT_256;
 export const SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS =
-  "0xde575850a9978d61094cbd1f8a897783d6d06084"; // Same address on mainnet and Rinkeby
+  "0xa604060890923ff400e8c6f5290461a83aedacec"; // Same address on mainnet and Rinkeby
 export const SHARED_STORE_FRONT_ADDRESS_MAINNET =
   "0x495f947276749ce646f68ac8c248420045cb7b5e";
 export const SHARED_STORE_FRONT_ADDRESS_RINKEBY =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,12 @@ export const OPENSEA_FEE_RECIPIENT =
   "0x8de9c5a032463c561423387a9648c5c7bcc5bc90";
 export const INVERSE_BASIS_POINT = 10_000; // 100 basis points per 1%
 export const MAX_UINT_256 = WyvernProtocol.MAX_UINT_256;
+export const SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS =
+  "0xde575850a9978d61094cbd1f8a897783d6d06084"; // Same address on mainnet and Rinkeby
+export const SHARED_STORE_FRONT_ADDRESS_MAINNET =
+  "0x495f947276749ce646f68ac8c248420045cb7b5e";
+export const SHARED_STORE_FRONT_ADDRESS_RINKEBY =
+  "0x88b48f654c30e99bc2e4a1559b4dcf1ad93fa656";
 export const ENJIN_COIN_ADDRESS = "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c";
 export const MANA_ADDRESS = "0x0f5d2fb29fb7d3cfee444a200298f468908cc942";
 export const ENJIN_ADDRESS = "0xfaaFDc07907ff5120a76b34b731b278c38d6043C";

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -157,6 +157,7 @@ import {
   hasErrorCode,
   getAssetItemType,
   BigNumberInput,
+  getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress,
 } from "./utils/utils";
 
 export class OpenSeaSDK {
@@ -777,7 +778,10 @@ export class OpenSeaSDK {
   ): CreateInputItem[] {
     return assets.map((asset, index) => ({
       itemType: getAssetItemType(this._getSchemaName(asset) ?? fallbackSchema),
-      token: asset.tokenAddress,
+      token:
+        getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
+          asset.tokenAddress
+        ),
       identifier: asset.tokenId ?? undefined,
       amount: quantities[index].toString() ?? "1",
     }));

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1095,8 +1095,8 @@ export const getAssetItemType = (schemaName?: WyvernSchemaName) => {
 };
 
 const SHARED_STOREFRONT_ADDRESSES = new Set([
-  SHARED_STORE_FRONT_ADDRESS_MAINNET,
-  SHARED_STORE_FRONT_ADDRESS_RINKEBY,
+  SHARED_STORE_FRONT_ADDRESS_MAINNET.toLowerCase(),
+  SHARED_STORE_FRONT_ADDRESS_RINKEBY.toLowerCase(),
 ]);
 
 /**
@@ -1107,7 +1107,7 @@ const SHARED_STOREFRONT_ADDRESSES = new Set([
  */
 export const getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress =
   (tokenAddress: string): string => {
-    return SHARED_STOREFRONT_ADDRESSES.has(tokenAddress)
+    return SHARED_STOREFRONT_ADDRESSES.has(tokenAddress.toLowerCase())
       ? SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
       : tokenAddress;
   };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -25,6 +25,9 @@ import {
   MERKLE_VALIDATOR_RINKEBY,
   NULL_ADDRESS,
   NULL_BLOCK_HASH,
+  SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS,
+  SHARED_STORE_FRONT_ADDRESS_MAINNET,
+  SHARED_STORE_FRONT_ADDRESS_RINKEBY,
 } from "../constants";
 import { ERC1155 } from "../contracts";
 import { ERC1155Abi } from "../typechain/contracts/ERC1155Abi";
@@ -1090,3 +1093,19 @@ export const getAssetItemType = (schemaName?: WyvernSchemaName) => {
       throw new Error(`Unknown schema name: ${schemaName}`);
   }
 };
+
+// Shared Storefront Lazy Mint Adapter helper functions
+
+const SHARED_STOREFRONT_ADDRESSES = new Set([
+  SHARED_STORE_FRONT_ADDRESS_MAINNET,
+  SHARED_STORE_FRONT_ADDRESS_RINKEBY,
+]);
+
+export const getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress =
+  (tokenAddress: string): string => {
+    return SHARED_STOREFRONT_ADDRESSES.has(tokenAddress)
+      ? // Replace shared storefront address with lazy mint adapter address
+        SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
+      : // Return existing token address otherwise
+        tokenAddress;
+  };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1094,18 +1094,20 @@ export const getAssetItemType = (schemaName?: WyvernSchemaName) => {
   }
 };
 
-// Shared Storefront Lazy Mint Adapter helper functions
-
 const SHARED_STOREFRONT_ADDRESSES = new Set([
   SHARED_STORE_FRONT_ADDRESS_MAINNET,
   SHARED_STORE_FRONT_ADDRESS_RINKEBY,
 ]);
 
+/**
+ * Checks if the token address is the shared storefront address and if so replaces
+ * that address with the lazy mint adapter addres. Otherwise, returns the input token address
+ * @param tokenAddress token address
+ * @returns input token address or lazy mint adapter address
+ */
 export const getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress =
   (tokenAddress: string): string => {
     return SHARED_STOREFRONT_ADDRESSES.has(tokenAddress)
-      ? // Replace shared storefront address with lazy mint adapter address
-        SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
-      : // Return existing token address otherwise
-        tokenAddress;
+      ? SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
+      : tokenAddress;
   };


### PR DESCRIPTION
Update asset token addresses when creating a buy order or creating a sell order to remap the shared storefront address to the lazy mint adapter address