### PR TITLE
support multi creator fees in the sdk 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "4.0.7",
+  "version": "4.0.8",
   "description": "JavaScript SDK for the OpenSea marketplace. Let users buy or sell crypto collectibles and other cryptogoods, all on your own site!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/__tests__/constants.ts
+++ b/src/__tests__/constants.ts
@@ -2,7 +2,7 @@ import { OpenSeaAPI } from "../api";
 import { CK_ADDRESS, CK_RINKEBY_ADDRESS } from "../constants";
 import { Network } from "../types";
 
-export const MAINNET_API_KEY = process.env.API_KEY;
+export const MAINNET_API_KEY = "822732a10f0c493b866f4db049b2ceec";
 export const RINKEBY_API_KEY = process.env.API_KEY;
 
 export const mainApi = new OpenSeaAPI(

--- a/src/__tests__/constants.ts
+++ b/src/__tests__/constants.ts
@@ -2,7 +2,7 @@ import { OpenSeaAPI } from "../api";
 import { CK_ADDRESS, CK_RINKEBY_ADDRESS } from "../constants";
 import { Network } from "../types";
 
-export const MAINNET_API_KEY = "822732a10f0c493b866f4db049b2ceec";
+export const MAINNET_API_KEY = process.env.API_KEY;
 export const RINKEBY_API_KEY = process.env.API_KEY;
 
 export const mainApi = new OpenSeaAPI(

--- a/src/__tests__/sdk/fees.ts
+++ b/src/__tests__/sdk/fees.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import { before, suite, test } from "mocha";
 import Web3 from "web3";
+import { feeBasisPointsReducer } from "src/utils";
 import {
   DEFAULT_BUYER_FEE_BASIS_POINTS,
   DEFAULT_SELLER_FEE_BASIS_POINTS,
@@ -51,12 +52,12 @@ suite("SDK: fees", () => {
     const collection = asset.collection;
     const buyerFeeBasisPoints =
       collection.openseaBuyerFeeBasisPoints + collection.devBuyerFeeBasisPoints;
-    const openseaSellerFeeBasisPoints = Object.values(
-      collection.fees?.openseaFees || []
-    ).reduce((sum, basisPoints) => basisPoints + sum, 0);
-    const devSellerFeeBasisPoints = Object.values(
-      collection.fees?.sellerFees || []
-    ).reduce((sum, basisPoints) => basisPoints + sum, 0);
+    const openseaSellerFeeBasisPoints = feeBasisPointsReducer(
+      collection.fees?.openseaFees
+    );
+    const devSellerFeeBasisPoints = feeBasisPointsReducer(
+      collection.fees?.sellerFees
+    );
     const sellerFeeBasisPoints =
       openseaSellerFeeBasisPoints + devSellerFeeBasisPoints;
 

--- a/src/__tests__/sdk/fees.ts
+++ b/src/__tests__/sdk/fees.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 import { before, suite, test } from "mocha";
 import Web3 from "web3";
-import { feeBasisPointsReducer } from "src/utils";
 import {
   DEFAULT_BUYER_FEE_BASIS_POINTS,
   DEFAULT_SELLER_FEE_BASIS_POINTS,
@@ -11,6 +10,7 @@ import {
 } from "../../constants";
 import { OpenSeaSDK } from "../../index";
 import { Network, OpenSeaAsset, OrderSide } from "../../types";
+import { feeBasisPointsReducer } from "../../utils/utils";
 import {
   CATS_IN_MECHS_ID,
   CK_ADDRESS,

--- a/src/__tests__/sdk/fees.ts
+++ b/src/__tests__/sdk/fees.ts
@@ -51,9 +51,14 @@ suite("SDK: fees", () => {
     const collection = asset.collection;
     const buyerFeeBasisPoints =
       collection.openseaBuyerFeeBasisPoints + collection.devBuyerFeeBasisPoints;
+    const openseaSellerFeeBasisPoints = Object.values(
+      collection.fees?.openseaFees || []
+    ).reduce((sum, basisPoints) => basisPoints + sum, 0);
+    const devSellerFeeBasisPoints = Object.values(
+      collection.fees?.sellerFees || []
+    ).reduce((sum, basisPoints) => basisPoints + sum, 0);
     const sellerFeeBasisPoints =
-      collection.openseaSellerFeeBasisPoints +
-      collection.devSellerFeeBasisPoints;
+      openseaSellerFeeBasisPoints + devSellerFeeBasisPoints;
 
     const buyerFees = await client.computeFees({
       asset,
@@ -62,6 +67,11 @@ suite("SDK: fees", () => {
     });
     assert.equal(buyerFees.totalBuyerFeeBasisPoints, buyerFeeBasisPoints);
     assert.equal(buyerFees.totalSellerFeeBasisPoints, sellerFeeBasisPoints);
+    assert.equal(
+      buyerFees.openseaSellerFeeBasisPoints,
+      openseaSellerFeeBasisPoints
+    );
+    assert.equal(buyerFees.devSellerFeeBasisPoints, devSellerFeeBasisPoints);
     assert.equal(
       buyerFees.devBuyerFeeBasisPoints,
       collection.devBuyerFeeBasisPoints

--- a/src/__tests__/sdk/fees.ts
+++ b/src/__tests__/sdk/fees.ts
@@ -10,7 +10,7 @@ import {
 } from "../../constants";
 import { OpenSeaSDK } from "../../index";
 import { Network, OpenSeaAsset, OrderSide } from "../../types";
-import { feeBasisPointsReducer } from "../../utils/utils";
+import { feesToBasisPoints } from "../../utils/utils";
 import {
   CATS_IN_MECHS_ID,
   CK_ADDRESS,
@@ -52,10 +52,10 @@ suite("SDK: fees", () => {
     const collection = asset.collection;
     const buyerFeeBasisPoints =
       collection.openseaBuyerFeeBasisPoints + collection.devBuyerFeeBasisPoints;
-    const openseaSellerFeeBasisPoints = feeBasisPointsReducer(
+    const openseaSellerFeeBasisPoints = feesToBasisPoints(
       collection.fees?.openseaFees
     );
-    const devSellerFeeBasisPoints = feeBasisPointsReducer(
+    const devSellerFeeBasisPoints = feesToBasisPoints(
       collection.fees?.sellerFees
     );
     const sellerFeeBasisPoints =

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,7 +3,6 @@ import { CROSS_CHAIN_SEAPORT_ADDRESS } from "@opensea/seaport-js/lib/constants";
 import {
   ConsiderationInputItem,
   CreateInputItem,
-  Fees,
   OrderComponents,
 } from "@opensea/seaport-js/lib/types";
 import { BigNumber } from "bignumber.js";
@@ -84,6 +83,7 @@ import {
   ECSignature,
   EventData,
   EventType,
+  Fees,
   FeeMethod,
   HowToCall,
   Network,
@@ -727,7 +727,7 @@ export class OpenSeaSDK {
       fees: Fees
     ): ConsiderationInputItem[] => {
       const considerationItems: ConsiderationInputItem[] = [];
-      fees?.sellerFees.forEach((recipient, basisPoints) =>
+      fees?.sellerFees.forEach((basisPoints, recipient) =>
         considerationItems.push(getConsiderationItem(basisPoints, recipient))
       );
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -688,7 +688,7 @@ export class OpenSeaSDK {
   }): Promise<{
     sellerFee: ConsiderationInputItem;
     openseaSellerFee: ConsiderationInputItem;
-    collectionSellerFee?: ConsiderationInputItem;
+    collectionSellerFee?: ConsiderationInputItem[];
     openseaBuyerFee?: ConsiderationInputItem;
     collectionBuyerFee?: ConsiderationInputItem;
   }> {
@@ -727,10 +727,9 @@ export class OpenSeaSDK {
         OPENSEA_FEE_RECIPIENT
       ),
       collectionSellerFee:
-        collectionSellerFeeBasisPoints > 0 && asset.collection.payoutAddress
-          ? getConsiderationItem(
-              collectionSellerFeeBasisPoints,
-              asset.collection.payoutAddress
+        collectionSellerFeeBasisPoints > 0 && asset.collection.fees
+          ? asset.collection.fees.map((fee) =>
+              getConsiderationItem(fee.basisPoints, fee.recipient)
             )
           : undefined,
       openseaBuyerFee:
@@ -2114,11 +2113,16 @@ export class OpenSeaSDK {
     let maxTotalBountyBPS = DEFAULT_MAX_BOUNTY;
 
     if (asset) {
+      const fees = asset.collection.fees;
       openseaBuyerFeeBasisPoints = +asset.collection.openseaBuyerFeeBasisPoints;
-      openseaSellerFeeBasisPoints =
-        +asset.collection.openseaSellerFeeBasisPoints;
+      openseaSellerFeeBasisPoints = +Object.values(
+        fees?.openseaFees || []
+      ).reduce((sum, basisPoints) => basisPoints + sum, 0);
       devBuyerFeeBasisPoints = +asset.collection.devBuyerFeeBasisPoints;
-      devSellerFeeBasisPoints = +asset.collection.devSellerFeeBasisPoints;
+      devSellerFeeBasisPoints = +Object.values(fees?.sellerFees || []).reduce(
+        (sum, basisPoints) => basisPoints + sum,
+        0
+      );
 
       maxTotalBountyBPS = openseaSellerFeeBasisPoints;
     }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -690,7 +690,7 @@ export class OpenSeaSDK {
   }): Promise<{
     sellerFee: ConsiderationInputItem;
     openseaSellerFee: ConsiderationInputItem;
-    collectionSellerFee?: ConsiderationInputItem[];
+    collectionSellerFees?: ConsiderationInputItem[];
     openseaBuyerFee?: ConsiderationInputItem;
     collectionBuyerFee?: ConsiderationInputItem;
   }> {
@@ -740,7 +740,7 @@ export class OpenSeaSDK {
         openseaSellerFeeBasisPoints,
         OPENSEA_FEE_RECIPIENT
       ),
-      collectionSellerFee:
+      collectionSellerFees:
         collectionSellerFeeBasisPoints > 0 && asset.collection.fees
           ? getConsiderationItemsFromSellerFees(asset.collection.fees)
           : undefined,
@@ -821,14 +821,15 @@ export class OpenSeaSDK {
       makeBigNumber(startAmount)
     );
 
-    const { openseaSellerFee, collectionSellerFee } = await this.getFees({
-      openseaAsset,
-      paymentTokenAddress,
-      startAmount: basePrice,
-    });
+    const { openseaSellerFee, collectionSellerFees: collectionSellerFees } =
+      await this.getFees({
+        openseaAsset,
+        paymentTokenAddress,
+        startAmount: basePrice,
+      });
     const considerationFeeItems = [
       openseaSellerFee,
-      collectionSellerFee,
+      collectionSellerFees,
     ].filter((item): item is ConsiderationInputItem => item !== undefined);
 
     const { executeAllActions } = await this.seaport.createOrder(
@@ -906,17 +907,20 @@ export class OpenSeaSDK {
       endAmount !== undefined ? makeBigNumber(endAmount) : undefined
     );
 
-    const { sellerFee, openseaSellerFee, collectionSellerFee } =
-      await this.getFees({
-        openseaAsset,
-        paymentTokenAddress,
-        startAmount: basePrice,
-        endAmount: endPrice,
-      });
+    const {
+      sellerFee,
+      openseaSellerFee,
+      collectionSellerFees: collectionSellerFees,
+    } = await this.getFees({
+      openseaAsset,
+      paymentTokenAddress,
+      startAmount: basePrice,
+      endAmount: endPrice,
+    });
     const considerationFeeItems = [
       sellerFee,
       openseaSellerFee,
-      collectionSellerFee,
+      collectionSellerFees,
     ].filter((item): item is ConsiderationInputItem => item !== undefined);
 
     if (buyerAddress) {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -138,7 +138,7 @@ import {
   getAssetItemType,
   BigNumberInput,
   getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress,
-  feeBasisPointsReducer,
+  feesToBasisPoints,
 } from "./utils/utils";
 
 export class OpenSeaSDK {
@@ -696,7 +696,7 @@ export class OpenSeaSDK {
   }> {
     // Seller fee basis points
     const openseaSellerFeeBasisPoints = DEFAULT_SELLER_FEE_BASIS_POINTS;
-    const collectionSellerFeeBasisPoints = feeBasisPointsReducer(
+    const collectionSellerFeeBasisPoints = feesToBasisPoints(
       asset.collection.fees?.sellerFees
     );
 
@@ -2127,9 +2127,9 @@ export class OpenSeaSDK {
     if (asset) {
       const fees = asset.collection.fees;
       openseaBuyerFeeBasisPoints = +asset.collection.openseaBuyerFeeBasisPoints;
-      openseaSellerFeeBasisPoints = +feeBasisPointsReducer(fees?.openseaFees);
+      openseaSellerFeeBasisPoints = +feesToBasisPoints(fees?.openseaFees);
       devBuyerFeeBasisPoints = +asset.collection.devBuyerFeeBasisPoints;
-      devSellerFeeBasisPoints = +feeBasisPointsReducer(fees?.sellerFees);
+      devSellerFeeBasisPoints = +feesToBasisPoints(fees?.sellerFees);
 
       maxTotalBountyBPS = openseaSellerFeeBasisPoints;
     }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -2129,7 +2129,7 @@ export class OpenSeaSDK {
       openseaBuyerFeeBasisPoints = +asset.collection.openseaBuyerFeeBasisPoints;
       openseaSellerFeeBasisPoints = +feeBasisPointsReducer(fees?.openseaFees);
       devBuyerFeeBasisPoints = +asset.collection.devBuyerFeeBasisPoints;
-      devSellerFeeBasisPoints = feeBasisPointsReducer(fees?.sellerFees);
+      devSellerFeeBasisPoints = +feeBasisPointsReducer(fees?.sellerFees);
 
       maxTotalBountyBPS = openseaSellerFeeBasisPoints;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-unused-modules */
-import { Fees } from "@opensea/seaport-js/lib/types";
 import BigNumber from "bignumber.js";
 import { AbiItem } from "web3-utils";
 import {
@@ -182,6 +181,12 @@ export enum TokenStandardVersion {
   ERC721v3 = "3.0",
 }
 
+// Collection fees mapping recipient address to basis points
+export interface Fees {
+  openseaFees: Map<string, number>;
+  sellerFees: Map<string, number>;
+}
+
 export interface WyvernNFTAsset {
   id: string;
   address: string;
@@ -337,7 +342,7 @@ export interface OpenSeaCollection extends OpenSeaFees {
   externalLink?: string;
   // Link to the collection's wiki, if available
   wikiLink?: string;
-  // Map of collection fees, holding OpenSea and seller fees
+  // Map of collection fees holding OpenSea and seller fees
   fees?: Fees | null;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-unused-modules */
+import { Fees } from "@opensea/seaport-js/lib/types";
 import BigNumber from "bignumber.js";
 import { AbiItem } from "web3-utils";
 import {
@@ -336,6 +337,8 @@ export interface OpenSeaCollection extends OpenSeaFees {
   externalLink?: string;
   // Link to the collection's wiki, if available
   wikiLink?: string;
+  // Map of collection fees, holding Opensea and seller fees
+  fees?: Fees | null;
 }
 
 export interface OpenSeaTraitStats {

--- a/src/types.ts
+++ b/src/types.ts
@@ -337,7 +337,7 @@ export interface OpenSeaCollection extends OpenSeaFees {
   externalLink?: string;
   // Link to the collection's wiki, if available
   wikiLink?: string;
-  // Map of collection fees, holding Opensea and seller fees
+  // Map of collection fees, holding OpenSea and seller fees
   fees?: Fees | null;
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1119,8 +1119,8 @@ export const getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAdd
 /**
  * Sums up the basis points for an Opensea or seller fee map and returns the
  * single numeric value if the map is not empty. Otherwise, it returns 0
- * @param fees fee map, which is generally the value of either Fees.openseaFees
- *  or Fees.sellerFees
+ * @param fees a `Fees` submap holding fees (either Fees.openseaFees
+ *  or Fees.sellerFees)
  * @returns sum of basis points in a fee map
  */
 export const feeBasisPointsReducer = (

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -381,8 +381,8 @@ export const collectionFromJSON = (collection: any): OpenSeaCollection => {
     externalLink: collection.external_url,
     wikiLink: collection.wiki_url,
     fees: {
-      openseaFees: collection.fees.opensea_fees,
-      sellerFees: collection.fees.seller_fees,
+      openseaFees: collection.fees.opensea_fees || {},
+      sellerFees: collection.fees.seller_fees || {},
     },
   };
 };
@@ -1115,3 +1115,20 @@ export const getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAdd
       ? SHARED_STOREFRONT_LAZY_MINT_ADAPTER_ADDRESS
       : tokenAddress;
   };
+
+/**
+ * Sums up the basis points for an Opensea or seller fee map and returns the
+ * single numeric value if the map is not empty. Otherwise, it returns 0
+ * @param fees fee map, which is generally the value of either Fees.openseaFees
+ *  or Fees.sellerFees
+ * @returns sum of basis points in a fee map
+ */
+export const feeBasisPointsReducer = (
+  fees: Map<string, number> | undefined
+): number => {
+  if (!fees) {
+    return 0;
+  }
+
+  return Object.values(fees).reduce((sum, basisPoints) => basisPoints + sum, 0);
+};

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -381,7 +381,7 @@ export const collectionFromJSON = (collection: any): OpenSeaCollection => {
     externalLink: collection.external_url,
     wikiLink: collection.wiki_url,
     fees: {
-      openSeaFees: collection.fees.opensea_fees,
+      openseaFees: collection.fees.opensea_fees,
       sellerFees: collection.fees.seller_fees,
     },
   };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -380,6 +380,10 @@ export const collectionFromJSON = (collection: any): OpenSeaCollection => {
     traitStats: collection.traits as OpenSeaTraitStats,
     externalLink: collection.external_url,
     wikiLink: collection.wiki_url,
+    fees: {
+      openSeaFees: collection.fees.opensea_fees,
+      sellerFees: collection.fees.seller_fees,
+    },
   };
 };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1123,7 +1123,7 @@ export const getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAdd
  *  or Fees.sellerFees)
  * @returns sum of basis points in a fee map
  */
-export const feeBasisPointsReducer = (
+export const feesToBasisPoints = (
   fees: Map<string, number> | undefined
 ): number => {
   if (!fees) {


### PR DESCRIPTION
Support multi creator fees in SDK by: 
1. adding `Fees` type that holds both Opensea and seller fee maps 
2. adding fees to collection type 
3. converting single consideration item to list of consideration items derived from the fee map in `getFees` 