### PR TITLE
fix error in fee iteration

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -726,12 +726,10 @@ export class OpenSeaSDK {
     const getConsiderationItemsFromSellerFees = (
       fees: Fees
     ): ConsiderationInputItem[] => {
-      const considerationItems: ConsiderationInputItem[] = [];
-      fees?.sellerFees.forEach((basisPoints, recipient) =>
-        considerationItems.push(getConsiderationItem(basisPoints, recipient))
+      const sellerFees = new Map(Object.entries(fees?.sellerFees));
+      return Object.keys(sellerFees).map((recipient) =>
+        getConsiderationItem(sellerFees.get(recipient) || 0, recipient)
       );
-
-      return considerationItems;
     };
 
     return {


### PR DESCRIPTION
Fixes error thrown when iterating over `fees?.sellerFees` key/value pairs. Instantiating a new `Map` object required for typescript (originally had it pull basis points using `sellerFees[recipient]`, but the `Fees` ts definition defines the values of `Fees` keys as `Map`s) 

Alternatively, we could avoid creating a map here by either: 
1. update `Fees` ts definition to just accept objects since the keys are strings anyway 
2. update `utils.collectionFromJSON` to instantiate `openseaFees` and `sellerFees` as `Map` entities like: 
```javascript
fees: {
      openseaFees: new Map(Object.entries(collection.fees.opensea_fees)) || new Map(),
      sellerFees: new Map(Object.entries(collection.fees.seller_fees)) || new Map(),
},
```