### PR TITLE
a cleaner way to make sure `Fees` submap is the correct type

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -726,7 +726,7 @@ export class OpenSeaSDK {
     const getConsiderationItemsFromSellerFees = (
       fees: Fees
     ): ConsiderationInputItem[] => {
-      const sellerFees = fees?.sellerFees as Map<string, number>;
+      const sellerFees = fees?.sellerFees;
       return Object.keys(sellerFees).map((recipient) =>
         getConsiderationItem(sellerFees.get(recipient) || 0, recipient)
       );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -726,7 +726,7 @@ export class OpenSeaSDK {
     const getConsiderationItemsFromSellerFees = (
       fees: Fees
     ): ConsiderationInputItem[] => {
-      const sellerFees = new Map(Object.entries(fees?.sellerFees));
+      const sellerFees = fees?.sellerFees as Map<string, number>;
       return Object.keys(sellerFees).map((recipient) =>
         getConsiderationItem(sellerFees.get(recipient) || 0, recipient)
       );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -726,7 +726,7 @@ export class OpenSeaSDK {
     const getConsiderationItemsFromSellerFees = (
       fees: Fees
     ): ConsiderationInputItem[] => {
-      const sellerFees = fees?.sellerFees;
+      const sellerFees = fees.sellerFees;
       return Object.keys(sellerFees).map((recipient) =>
         getConsiderationItem(sellerFees.get(recipient) || 0, recipient)
       );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -726,12 +726,10 @@ export class OpenSeaSDK {
     const getConsiderationItemsFromSellerFees = (
       fees: Fees
     ): ConsiderationInputItem[] => {
-      const considerationItems: ConsiderationInputItem[] = [];
-      fees?.sellerFees.forEach((basisPoints, recipient) =>
-        considerationItems.push(getConsiderationItem(basisPoints, recipient))
+      const sellerFees = new Map(Object.entries(fees?.sellerFees));
+      return Object.keys(sellerFees).map((recipient) =>
+        getConsiderationItem(sellerFees.get(recipient) || 0, recipient)
       );
-
-      return considerationItems;
     };
 
     return {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -381,8 +381,10 @@ export const collectionFromJSON = (collection: any): OpenSeaCollection => {
     externalLink: collection.external_url,
     wikiLink: collection.wiki_url,
     fees: {
-      openseaFees: collection.fees.opensea_fees || {},
-      sellerFees: collection.fees.seller_fees || {},
+      openseaFees:
+        new Map(Object.entries(collection.fees.opensea_fees)) || new Map(),
+      sellerFees:
+        new Map(Object.entries(collection.fees.seller_fees)) || new Map(),
     },
   };
 };
@@ -1130,5 +1132,8 @@ export const feesToBasisPoints = (
     return 0;
   }
 
-  return Object.values(fees).reduce((sum, basisPoints) => basisPoints + sum, 0);
+  return Array.from(fees.values()).reduce(
+    (sum, basisPoints) => basisPoints + sum,
+    0
+  );
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -381,10 +381,8 @@ export const collectionFromJSON = (collection: any): OpenSeaCollection => {
     externalLink: collection.external_url,
     wikiLink: collection.wiki_url,
     fees: {
-      openseaFees:
-        new Map(Object.entries(collection.fees.opensea_fees)) || new Map(),
-      sellerFees:
-        new Map(Object.entries(collection.fees.seller_fees)) || new Map(),
+      openseaFees: new Map(Object.entries(collection.fees.opensea_fees || {})),
+      sellerFees: new Map(Object.entries(collection.fees.seller_fees || {})),
     },
   };
 };


### PR DESCRIPTION
No functionality change - just cleaner syntax :) 