### PR TITLE
Add salt and domain params to createBuyOrder and createSellOrder

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@opensea/seaport-js": "^1.0.2",
+    "@opensea/seaport-js": "^1.0.6",
     "ajv": "^8.11.0",
     "bignumber.js": "9.0.2",
     "ethereumjs-abi": "git+https://github.com/ProjectWyvern/ethereumjs-abi.git",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -11,7 +11,6 @@ import { isValidAddress } from "ethereumjs-util";
 import { providers } from "ethers";
 import { EventEmitter, EventSubscription } from "fbemitter";
 import * as _ from "lodash";
-import { domain } from "process";
 import Web3 from "web3";
 import { WyvernProtocol } from "wyvern-js";
 import * as WyvernSchemas from "wyvern-schemas";
@@ -789,8 +788,8 @@ export class OpenSeaSDK {
    * @param options.accountAddress Address of the maker's wallet
    * @param options.startAmount Value of the offer, in units of the payment token (or wrapped ETH if no payment token address specified)
    * @param options.quantity The number of assets to bid for (if fungible or semi-fungible). Defaults to 1. In units, not base units, e.g. not wei
-   * @param input.domain An optional domain to be hashed and included in the first four bytes of the random salt.
-   * @param input.salt Arbitrary salt. If not passed in, a random salt will be generated with the first four bytes being the domain hash or empty.
+   * @param options.domain An optional domain to be hashed and included in the first four bytes of the random salt.
+   * @param options.salt Arbitrary salt. If not passed in, a random salt will be generated with the first four bytes being the domain hash or empty.
    * @param options.expirationTime Expiration time for the order, in seconds
    * @param options.paymentTokenAddress Optional address for using an ERC-20 token in the order. If unspecified, defaults to WETH
    */
@@ -799,6 +798,8 @@ export class OpenSeaSDK {
     accountAddress,
     startAmount,
     quantity = 1,
+    domain = "",
+    salt = "",
     expirationTime,
     paymentTokenAddress,
   }: {
@@ -874,6 +875,8 @@ export class OpenSeaSDK {
    * @param options.startAmount Price of the asset at the start of the auction. Units are in the amount of a token above the token's decimal places (integer part). For example, for ether, expected units are in ETH, not wei.
    * @param options.endAmount Optional price of the asset at the end of its expiration time. Units are in the amount of a token above the token's decimal places (integer part). For example, for ether, expected units are in ETH, not wei.
    * @param options.quantity The number of assets to sell (if fungible or semi-fungible). Defaults to 1. In units, not base units, e.g. not wei.
+   * @param options.domain An optional domain to be hashed and included in the first four bytes of the random salt.
+   * @param options.salt Arbitrary salt. If not passed in, a random salt will be generated with the first four bytes being the domain hash or empty.
    * @param options.listingTime Optional time when the order will become fulfillable, in UTC seconds. Undefined means it will start now.
    * @param options.expirationTime Expiration time for the order, in UTC seconds.
    * @param options.paymentTokenAddress Address of the ERC-20 token to accept in return. If undefined or null, uses Ether.
@@ -885,6 +888,8 @@ export class OpenSeaSDK {
     startAmount,
     endAmount,
     quantity = 1,
+    domain = "",
+    salt = "",
     listingTime,
     expirationTime,
     paymentTokenAddress = NULL_ADDRESS,
@@ -895,6 +900,8 @@ export class OpenSeaSDK {
     startAmount: BigNumberInput;
     endAmount?: BigNumberInput;
     quantity?: BigNumberInput;
+    domain?: string;
+    salt?: string;
     listingTime?: string;
     expirationTime?: BigNumberInput;
     paymentTokenAddress?: string;
@@ -949,6 +956,8 @@ export class OpenSeaSDK {
           expirationTime?.toString() ??
           getMaxOrderExpirationTimestamp().toString(),
         zone: DEFAULT_ZONE_BY_NETWORK[this._networkName],
+        domain: domain,
+        salt: salt,
         restrictedByZone: true,
         allowPartialFills: true,
       },

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -855,8 +855,8 @@ export class OpenSeaSDK {
           expirationTime?.toString() ??
           getMaxOrderExpirationTimestamp().toString(),
         zone: DEFAULT_ZONE_BY_NETWORK[this._networkName],
-        domain: domain,
-        salt: salt,
+        domain,
+        salt,
         restrictedByZone: true,
         allowPartialFills: true,
       },
@@ -956,8 +956,8 @@ export class OpenSeaSDK {
           expirationTime?.toString() ??
           getMaxOrderExpirationTimestamp().toString(),
         zone: DEFAULT_ZONE_BY_NETWORK[this._networkName],
-        domain: domain,
-        salt: salt,
+        domain,
+        salt,
         restrictedByZone: true,
         allowPartialFills: true,
       },

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -11,6 +11,7 @@ import { isValidAddress } from "ethereumjs-util";
 import { providers } from "ethers";
 import { EventEmitter, EventSubscription } from "fbemitter";
 import * as _ from "lodash";
+import { domain } from "process";
 import Web3 from "web3";
 import { WyvernProtocol } from "wyvern-js";
 import * as WyvernSchemas from "wyvern-schemas";
@@ -788,6 +789,8 @@ export class OpenSeaSDK {
    * @param options.accountAddress Address of the maker's wallet
    * @param options.startAmount Value of the offer, in units of the payment token (or wrapped ETH if no payment token address specified)
    * @param options.quantity The number of assets to bid for (if fungible or semi-fungible). Defaults to 1. In units, not base units, e.g. not wei
+   * @param input.domain An optional domain to be hashed and included in the first four bytes of the random salt.
+   * @param input.salt Arbitrary salt. If not passed in, a random salt will be generated with the first four bytes being the domain hash or empty.
    * @param options.expirationTime Expiration time for the order, in seconds
    * @param options.paymentTokenAddress Optional address for using an ERC-20 token in the order. If unspecified, defaults to WETH
    */
@@ -803,6 +806,8 @@ export class OpenSeaSDK {
     accountAddress: string;
     startAmount: BigNumberInput;
     quantity?: BigNumberInput;
+    domain?: string;
+    salt?: string;
     expirationTime?: BigNumberInput;
     paymentTokenAddress?: string;
   }): Promise<OrderV2> {
@@ -849,6 +854,8 @@ export class OpenSeaSDK {
           expirationTime?.toString() ??
           getMaxOrderExpirationTimestamp().toString(),
         zone: DEFAULT_ZONE_BY_NETWORK[this._networkName],
+        domain: domain,
+        salt: salt,
         restrictedByZone: true,
         allowPartialFills: true,
       },


### PR DESCRIPTION
Allow users to pass in optional salt and/or domain during order creation

- If a salt && domain are passed in, salt will be used for order (domain will be ignored)
- If only salt is passed in, salt will be used for order
- If only domain is passed in, domain will be hashed and added to first four bytes of salt, middle 20 bytes will be empty, last 8 bytes will be random
- If neither salt nor domain are passed in, first 24 bytes will be empty, last 8 bytes will be random
- Logic for salt creation is stored in `createOrder` in `seaport-js`