### PR TITLE
Got allows a redirect to a UNIX socket CVE-2022-33987

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "isomorphic-unfetch": "^2.1.1",
         "lodash": "^4.17.21",
         "query-string": "^6.11.1",
-        "web3": "1.7.0",
+        "web3": "1.8.0",
         "wyvern-js": "git+https://github.com/ProjectOpenSea/wyvern-js.git#7429b1f2dd123f012cae1f3144a069e91ecd0682",
         "wyvern-schemas": "git+https://github.com/ProjectOpenSea/wyvern-schemas.git#af1fc62dd58144b60487df690c77dcf8daa45669"
       },
@@ -1040,18 +1040,18 @@
       "dev": true
     },
     "node_modules/@ethereumjs/common": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.4.tgz",
-      "integrity": "sha512-RDJh/R/EAr+B7ZRg5LfJ0BIpf/1LydFgYdvZEuTraojCbVypO2sQ+QnpP5u2wJf9DASyooKqu8O4FJEWUV6NXw==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
+      "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
       "dependencies": {
         "crc-32": "^1.2.0",
         "ethereumjs-util": "^7.1.4"
       }
     },
     "node_modules/@ethereumjs/common/node_modules/@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
       "dependencies": {
         "@types/node": "*"
       }


### PR DESCRIPTION
Affected versions of this package are vulnerable to Open Redirect due to missing verification of requested URLs. It allowed a victim to be redirected to a UNIX socket.

GHSA-pfrx-2q88-qq97
