### PR TITLE
update fulfillment methods to accept domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@opensea/seaport-js": "^1.0.6",
+    "@opensea/seaport-js": "^1.0.7",
     "ajv": "^8.11.0",
     "bignumber.js": "9.0.2",
     "ethereumjs-abi": "git+https://github.com/ProjectWyvern/ethereumjs-abi.git",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -999,7 +999,7 @@ export class OpenSeaSDK {
    * @param options.order The order to fulfill, a.k.a. "take"
    * @param options.accountAddress The taker's wallet address
    * @param options.recipientAddress The optional address to receive the order's item(s) or curriencies. If not specified, defaults to accountAddress
-   * @param options.domain
+   * @param options.domain An optional domain to be hashed and included at the end of fulfillment calldata
    * @returns Transaction hash for fulfilling the order
    */
   public async fulfillOrder({
@@ -1119,6 +1119,7 @@ export class OpenSeaSDK {
    * @param param0 __namedParameters Object
    * @param order The order to cancel
    * @param accountAddress The order maker's wallet address
+   * @param domain An optional domain to be hashed and included at the end of fulfillment calldata
    */
   public async cancelOrder({
     order,
@@ -2804,6 +2805,7 @@ export class OpenSeaSDK {
    * Instead of signing an off-chain order, you can approve an order
    * with on on-chain transaction using this method
    * @param order Order to approve
+   * @param domain An optional domain to be hashed and included at the end of fulfillment calldata
    * @returns Transaction hash of the approval transaction
    */
   public async approveOrder(order: OrderV2, domain = "") {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -947,7 +947,7 @@ export class OpenSeaSDK {
   private async fulfillPrivateOrder({
     order,
     accountAddress,
-    domain = "",
+    domain,
   }: {
     order: OrderV2;
     accountAddress: string;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -2806,7 +2806,7 @@ export class OpenSeaSDK {
    * @param order Order to approve
    * @returns Transaction hash of the approval transaction
    */
-  public async approveOrder(order: OrderV2, domain: string = "") {
+  public async approveOrder(order: OrderV2, domain = "") {
     this._dispatch(EventType.ApproveOrder, {
       orderV2: order,
       accountAddress: order.maker.address,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -777,8 +777,8 @@ export class OpenSeaSDK {
     accountAddress,
     startAmount,
     quantity = 1,
-    domain = "",
-    salt = "",
+    domain,
+    salt,
     expirationTime,
     paymentTokenAddress,
   }: {
@@ -864,8 +864,8 @@ export class OpenSeaSDK {
     startAmount,
     endAmount,
     quantity = 1,
-    domain = "",
-    salt = "",
+    domain,
+    salt,
     listingTime,
     expirationTime,
     paymentTokenAddress = NULL_ADDRESS,
@@ -1006,7 +1006,7 @@ export class OpenSeaSDK {
     order,
     accountAddress,
     recipientAddress,
-    domain = "",
+    domain,
   }: {
     order: OrderV2;
     accountAddress: string;
@@ -1103,7 +1103,7 @@ export class OpenSeaSDK {
   private async cancelSeaportOrders({
     orders,
     accountAddress,
-    domain = "",
+    domain,
   }: {
     orders: OrderComponents[];
     accountAddress: string;
@@ -1125,7 +1125,7 @@ export class OpenSeaSDK {
   public async cancelOrder({
     order,
     accountAddress,
-    domain = "",
+    domain,
   }: {
     order: OrderV2;
     accountAddress: string;
@@ -2809,7 +2809,7 @@ export class OpenSeaSDK {
    * @param domain An optional domain to be hashed and included at the end of fulfillment calldata
    * @returns Transaction hash of the approval transaction
    */
-  public async approveOrder(order: OrderV2, domain = "") {
+  public async approveOrder(order: OrderV2, domain?: string) {
     this._dispatch(EventType.ApproveOrder, {
       orderV2: order,
       accountAddress: order.maker.address,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -974,7 +974,7 @@ export class OpenSeaSDK {
               value: counterOrder.parameters.offer[0].startAmount,
             },
             accountAddress,
-            domain
+            domain,
           })
           .transact();
         const transactionReceipt = await transaction.wait();
@@ -1033,7 +1033,7 @@ export class OpenSeaSDK {
           order: order.protocolData,
           accountAddress,
           recipientAddress,
-          domain
+          domain,
         });
         const transaction = await executeAllActions();
         transactionHash = transaction.hash;
@@ -1138,7 +1138,7 @@ export class OpenSeaSDK {
         transactionHash = await this.cancelSeaportOrders({
           orders: [order.protocolData.parameters],
           accountAddress,
-          domain
+          domain,
         });
         break;
       }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1023,6 +1023,7 @@ export class OpenSeaSDK {
       return this.fulfillPrivateOrder({
         order,
         accountAddress,
+        domain,
       });
     }
 


### PR DESCRIPTION
- Add optional `domain` param to fulfillment methods to match functionality in `seaport-js` [PR](https://github.com/ProjectOpenSea/seaport-js/pull/117)
- Appends tags to fulfillment calldata