### PR TITLE
add header to requests for tracking

### DIFF
--- a/src/__tests__/api/api.ts
+++ b/src/__tests__/api/api.ts
@@ -17,13 +17,14 @@ suite("api", () => {
     assert.equal(testnetApi.apiBaseUrl, "https://testnets-api.opensea.io");
   });
 
-  test("Includes API key in token request", async () => {
+  test("Includes API key and origin in token request", async () => {
     const oldLogger = testnetApi.logger;
 
     const logPromise = new Promise<void>((resolve, reject) => {
       testnetApi.logger = (log) => {
         try {
           assert.include(log, `"X-API-KEY":"${TESTNET_API_KEY}"`);
+          assert.include(log, `"X-ORIGIN":"opensea-js"`);
           resolve();
         } catch (e) {
           reject(e);

--- a/src/api.ts
+++ b/src/api.ts
@@ -392,6 +392,7 @@ export class OpenSeaAPI {
       headers: {
         ...(apiKey ? { "X-API-KEY": apiKey } : {}),
         ...(opts.headers || {}),
+        ...{ "X-ORIGIN": "opensea-js" },
       },
     };
 


### PR DESCRIPTION
i'm not familiar with best practices when using custom tags so definitely open to suggestions, but just adding something to help gain some visibility into where certain requests are coming from 