### PR TITLE
Add sdk version as header in API requests

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -392,7 +392,7 @@ export class OpenSeaAPI {
       ...opts,
       headers: {
         ...(apiKey ? { "X-API-KEY": apiKey } : {}),
-        ...{ "sdk-version": sdkVersion },
+        ...{ "SDK-Version": sdkVersion },
         ...(opts.headers || {}),
       },
     };

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import "isomorphic-unfetch";
 import _ from "lodash";
 import * as QueryString from "query-string";
+import { version as sdkVersion } from "../package.json";
 import {
   API_BASE_MAINNET,
   API_BASE_TESTNET,
@@ -391,6 +392,7 @@ export class OpenSeaAPI {
       ...opts,
       headers: {
         ...(apiKey ? { "X-API-KEY": apiKey } : {}),
+        ...{ "sdk-version": sdkVersion },
         ...(opts.headers || {}),
       },
     };


### PR DESCRIPTION
Sending the SDK version in our requests will make it quicker to diagnose issues which are only seen in the SDK and not the API.