### PR TITLE
Add toChecksumAddress to constants in isValidProtocol

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1145,6 +1145,6 @@ export const isValidProtocol = (protocolAddress: string): boolean => {
   const validProtocolAddresses = [
     CROSS_CHAIN_SEAPORT_ADDRESS,
     CROSS_CHAIN_SEAPORT_V1_4_ADDRESS,
-  ];
+  ].map((address) => Web3.utils.toChecksumAddress(address));
   return validProtocolAddresses.includes(checkSumAddress);
 };


### PR DESCRIPTION
Looks like `isValidProtocol()` that was added recently will fail because the constants used in validProtocolAddresses are not also passed through `Web3.utils.toChecksumAddress()`

Example of failing code:

```js
const isValidProtocol = (protocolAddress) => {
  const checkSumAddress = Web3.utils.toChecksumAddress(protocolAddress);

  const validProtocolAddresses = [
    CROSS_CHAIN_SEAPORT_ADDRESS,
    CROSS_CHAIN_SEAPORT_V1_4_ADDRESS,
  ];

  return validProtocolAddresses.includes(checkSumAddress);
};

// This should be valid and return true
console.log(isValidProtocol(CROSS_CHAIN_SEAPORT_ADDRESS)); // returns false
```

Added a map for `validProtocolAddresses` to make sure all valid protocol addresses are also the checksum version.


```js
// [...]
   const validProtocolAddresses = [
      CROSS_CHAIN_SEAPORT_ADDRESS,
      CROSS_CHAIN_SEAPORT_V1_4_ADDRESS,
   ].map((address) => Web3.utils.toChecksumAddress(address));

   return validProtocolAddresses.includes(checkSumAddress);
}

console.log(isValidProtocol(CROSS_CHAIN_SEAPORT_ADDRESS)); // returns true
```

First time contributing so let me know if I'm misunderstanding anything or need to modify the PR.
