### PR TITLE
fix fulfillment

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1039,14 +1039,16 @@ export class OpenSeaSDK {
       throw new Error("Unsupported protocol");
     }
 
-    if (!order.clientSignature && order.orderHash) {
+    if (order.orderHash) {
       const result = await this.api.generateFulfillmentData(
         accountAddress,
         order.orderHash,
         order.protocolAddress,
         order.side
       );
-      order.clientSignature = result.fulfillment_data.orders[0].signature;
+      const signature = result.fulfillment_data.orders[0].signature;
+      order.clientSignature = signature;
+      order.protocolData.signature = signature;
     }
 
     const isPrivateListing = !!order.taker;


### PR DESCRIPTION
Issue is brought up here: https://github.com/ProjectOpenSea/opensea-js/issues/870

We use ```seaport.fulfillOrder``` to fulfill orders, and we pass the ```order.protocolData``` to that method. The protocolData needs to have a set signature, and I previously only update the orderV2 object