### PR TITLE
fix dependencies @opensea/seaport-js to ^1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "types": "lib/index.d.ts",
   "dependencies": {
-    "@opensea/seaport-js": "^1.0.10",
+    "@opensea/seaport-js": "^1.2.0",
     "ajv": "8.11.0",
     "axios": "^1.3.4",
     "bignumber.js": "9.0.2",


### PR DESCRIPTION
@opensea/seaport-js version  v1.1.0 is automatically installed.    But it does not contain the constant CROSS_CHAIN_SEAPORT_V1_5_ADDRESS - It throws an error 'Unsupported protocol' for protocolAddress = 0x00000000000000adc04c56bf30ac9d3c0aaf14dc.