### PR TITLE
Add X-Requested-With header to API calls

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -469,6 +469,7 @@ export class OpenSeaAPI {
       ...opts,
       headers: {
         ...(apiKey ? { "X-API-KEY": apiKey } : {}),
+        ...{ "X-Requested-With": "Opensea-JS" },
         ...(opts.headers || {}),
       },
     };


### PR DESCRIPTION
Adding header so we can determine how many calls are made via the SDK versus the API