### PR TITLE
Consolidate to one getBalance function

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,21 +151,12 @@ const asset = {
   tokenId: "1", // Token ID
 }
 
-const balance = await openseaSDK.getAssetBalance({
+const balance = await openseaSDK.getBalance({
   accountAddress, // string
   asset, // Asset
 })
 
 const ownsKitty = balance.greaterThan(0)
-```
-
-You can use this same method for fungible ERC-20 tokens like wrapped ETH (WETH). As a convenience, you can use this fungible wrapper for checking fungible balances:
-
-```JavaScript
-const balanceOfWETH = await openseaSDK.getTokenBalance({
-  accountAddress, // string
-  tokenAddress: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
-})
 ```
 
 ### Making Offers

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -911,7 +911,7 @@ export class OpenSeaSDK {
    * @param asset The Asset to check balance for
    * @param retries How many times to retry if balance is 0
    */
-  public async getAssetBalance(
+  public async getBalance(
     { accountAddress, asset }: { accountAddress: string; asset: Asset },
     retries = 1
   ): Promise<BigNumber> {
@@ -971,37 +971,8 @@ export class OpenSeaSDK {
     } else {
       await delay(500);
       // Recursively check owner again
-      return await this.getAssetBalance({ accountAddress, asset }, retries - 1);
+      return await this.getBalance({ accountAddress, asset }, retries - 1);
     }
-  }
-
-  /**
-   * Get the balance of a fungible token.
-   * Convenience method for getAssetBalance for fungibles
-   * @param param0 __namedParameters Object
-   * @param accountAddress Account address to check
-   * @param tokenAddress The address of the token to check balance for
-   * @param schemaName Optional schema name for the fungible token
-   * @param retries Number of times to retry if balance is undefined
-   */
-  public async getTokenBalance(
-    {
-      accountAddress,
-      tokenAddress,
-      schemaName = WyvernSchemaName.ERC20,
-    }: {
-      accountAddress: string;
-      tokenAddress: string;
-      schemaName?: WyvernSchemaName;
-    },
-    retries = 1
-  ) {
-    const asset: Asset = {
-      tokenId: null,
-      tokenAddress,
-      schemaName,
-    };
-    return this.getAssetBalance({ accountAddress, asset }, retries);
   }
 
   /**


### PR DESCRIPTION
The naming conventions were confusing between `getTokenBalance` and `getAssetBalance` since they are all tokens and assets. Instead we decided to use a single function for all schemas.