### PR TITLE
Remove encodeDefaultCall and generateDefaultValue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { OpenSeaAPI } from "./api";
 import { OpenSeaSDK } from "./sdk";
 import { Network, EventData, EventType } from "./types";
 export { orderToJSON, orderFromJSON } from "./utils/utils";
-export { encodeDefaultCall } from "./utils/schemas/schema";
 
 /**
  * Example setup:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-unused-modules */
 import BigNumber from "bignumber.js";
+import { BigNumberish } from "ethers";
 import { AbiItem } from "web3-utils";
 import type { OrderV2 } from "./orders/types";
 
@@ -61,7 +62,7 @@ export interface EventData {
   accountAddress?: string;
   toAddress?: string;
   proxyAddress?: string;
-  amount?: BigNumber;
+  amount?: BigNumberish;
   contractAddress?: string;
   assets?: AssetType[];
   asset?: AssetType;

--- a/src/utils/schemas/schema.ts
+++ b/src/utils/schemas/schema.ts
@@ -3,8 +3,7 @@ import { goerliSchemas } from "./goerli/index";
 import { mainSchemas } from "./main/index";
 import { rinkebySchemas } from "./rinkeby/index";
 import { EventInputKind } from "./types";
-import { AbiType, AnnotatedFunctionABI, FunctionInputKind } from "../../types";
-import { generateDefaultValue } from "../utils";
+import { AbiType, AnnotatedFunctionABI } from "../../types";
 
 export interface LimitedCallSpec {
   target: string;
@@ -119,21 +118,6 @@ export type DefaultCallEncoder = (
   abi: AnnotatedFunctionABI,
   address: string
 ) => string;
-
-export const encodeDefaultCall: DefaultCallEncoder = (abi, address) => {
-  const parameters = abi.inputs.map((input) => {
-    switch (input.kind) {
-      case FunctionInputKind.Replaceable:
-        return generateDefaultValue(input.type);
-      case FunctionInputKind.Owner:
-        return address;
-      case FunctionInputKind.Asset:
-      default:
-        return input.value;
-    }
-  });
-  return encodeCall(abi, parameters);
-};
 
 export const schemas = {
   goerli: goerliSchemas,


### PR DESCRIPTION
Starting to transition all the BigNumber dependencies to use the built-in BigNumber in ethers. Until then, they is a weird mix with conversations between them as seen in the `toBaseUnitAmount` function.

This PR removes:
- encodeDefaultCall
- generateDefaultValue

Additionally, use `parseEther` when wrapping and unwrapping ether.