### PR TITLE
Fix stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,5 +15,6 @@ jobs:
           days-before-stale: 60
           days-before-close: 14
           operations-per-run: 100
+          ascending: true
           exempt-pr-labels: "work-in-progress"
           exempt-issue-labels: "work-in-progress"


### PR DESCRIPTION
Set `ascending: true` to close oldest issues first (reaching max operations-per-run when going descending and not closing any issues)