### PR TITLE
Add automerge to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
By default, Renovate raises PRs but leaves them to someone or something else to merge them. By configuring this setting, you allow Renovate to automerge PRs or even branches. Using automerge reduces the amount of human intervention required.

Instead of automerging all PRs,  leave major dependency updates to a human to review first.

Ref: https://docs.renovatebot.com/configuration-options/#automerge