### PR TITLE
Remove es module interop

### DIFF
--- a/src/__tests__/sdk/orders.ts
+++ b/src/__tests__/sdk/orders.ts
@@ -7,7 +7,7 @@ import { OpenSeaSDK } from "../../index";
 import { Network, OrderJSON } from "../../types";
 import { orderFromJSON } from "../../utils/utils";
 import { MAINNET_API_KEY } from "../constants";
-import ordersJSONFixture from "../fixtures/orders.json";
+import ordersJSONFixture = require("../fixtures/orders.json");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const ordersJSON = ordersJSONFixture as any;

--- a/src/__tests__/support/setup.ts
+++ b/src/__tests__/support/setup.ts
@@ -1,5 +1,5 @@
-import chai from "chai";
-import chaiAsPromised from "chai-as-promised";
+import chai = require("chai");
+import chaiAsPromised = require("chai-as-promised");
 
 chai.should();
 chai.use(chaiAsPromised);

--- a/src/abi/ERC1155.ts
+++ b/src/abi/ERC1155.ts
@@ -1,4 +1,4 @@
-import ERC1155Abi from "./ERC1155Abi.json";
+import ERC1155Abi = require("./ERC1155Abi.json");
 import { PartialReadonlyContractAbi } from "../types";
 
 export const ERC1155 = ERC1155Abi as PartialReadonlyContractAbi;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,8 @@
   "include": ["./src/**/*", "./node_modules/types-bn/index.d.ts"],
   "compilerOptions": {
     "outDir": "lib",
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "esnext"],
-    "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
@@ -18,7 +17,6 @@
     "sourceMap": true,
     "strict": true,
     "declaration": true,
-    "esModuleInterop": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
For motivation behind this change, see: https://www.semver-ts.org/#module-interop

JS Compiler Target version bumped to match seaport-js