### PR TITLE
Use ethers fetchJson

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
     node: true,
   },
   root: true,
-  ignorePatterns: ["docs", "lib", "src/typechain"],
+  ignorePatterns: ["docs", "lib", "coverage", "src/typechain"],
   reportUnusedDisableDirectives: true,
   parser: "@typescript-eslint/parser",
   plugins: ["@typescript-eslint", "import", "prettier"],

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 lib
 docs
 .nyc_output
+coverage
 src/typechain

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "JavaScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@opensea/seaport-js": "^2.0.0",
-    "ethers": "^5.7.2",
-    "isomorphic-unfetch": "^4.0.2"
+    "ethers": "^5.7.2"
   },
   "devDependencies": {
     "@typechain/ethers-v5": "^11.0.0",

--- a/test/api/api.spec.ts
+++ b/test/api/api.spec.ts
@@ -58,7 +58,7 @@ suite("API", () => {
     try {
       await mainAPI.get(`/asset/${BAYC_CONTRACT_ADDRESS}/202020202020`);
     } catch (error) {
-      assert.include((error as Error).message, "Not found");
+      assert.include((error as Error).message, "status=404");
     }
   });
 });


### PR DESCRIPTION
Removes `isomorphic-unfetch` dependency in favor of ethers fetchJson that uses fetch or node http/s under the hood. Should help alleviate browser build pipeline challenges.

Down to 2 dependencies in this package!