### PR TITLE
Fixes underflow when try to use fractional ETH as number in orders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensea-js",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opensea-js",
-      "version": "6.0.4",
+      "version": "6.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "JavaScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -944,14 +944,11 @@ export class OpenSeaSDK {
     const decimals = paymentToken?.decimals ?? 18;
 
     const startAmountWei = ethers.utils.parseUnits(
-      FixedNumber.from(startAmount).toString(),
+      startAmount.toString(),
       decimals
     );
     const endAmountWei = endAmount
-      ? ethers.utils.parseUnits(
-          FixedNumber.from(endAmount).toString(),
-          decimals
-        )
+      ? ethers.utils.parseUnits(endAmount.toString(), decimals)
       : undefined;
     const priceDiffWei =
       endAmountWei !== undefined
@@ -962,10 +959,7 @@ export class OpenSeaSDK {
     const endPrice = endAmountWei;
     const extra = priceDiffWei;
     const reservePrice = englishAuctionReservePrice
-      ? ethers.utils.parseUnits(
-          FixedNumber.from(startAmount).toString(),
-          decimals
-        )
+      ? ethers.utils.parseUnits(startAmount.toString(), decimals)
       : undefined;
 
     // Validation

--- a/test/integration/postOrder.spec.ts
+++ b/test/integration/postOrder.spec.ts
@@ -15,7 +15,7 @@ suite("SDK: order posting", () => {
   test("Post Buy Order", async () => {
     const buyOrder = {
       accountAddress: walletAddress,
-      startAmount: OFFER_AMOUNT,
+      startAmount: +OFFER_AMOUNT,
       asset: {
         tokenAddress: "0x1a92f7381b9f03921564a437210bb9396471050c",
         tokenId: "2288",
@@ -34,7 +34,7 @@ suite("SDK: order posting", () => {
 
     const sellOrder = {
       accountAddress: walletAddress,
-      startAmount: LISTING_AMOUNT,
+      startAmount: +LISTING_AMOUNT,
       asset: {
         tokenAddress: TOKEN_ADDRESS,
         tokenId: TOKEN_ID,

--- a/test/integration/postOrder.spec.ts
+++ b/test/integration/postOrder.spec.ts
@@ -34,7 +34,7 @@ suite("SDK: order posting", () => {
 
     const sellOrder = {
       accountAddress: walletAddress,
-      startAmount: +LISTING_AMOUNT,
+      startAmount: LISTING_AMOUNT,
       asset: {
         tokenAddress: TOKEN_ADDRESS,
         tokenId: TOKEN_ID,


### PR DESCRIPTION
## Motivation

Fixes #1022 

## Solution

BigNumberish was being parsed as FixedNumber and cast to string. Instead casted BigNumberish to string directly.

## Testing

Changed integration tests to use numbers instead of strings.
