### PR TITLE
expose new field for remaining quantity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "JavaScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data!",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/orders/types.ts
+++ b/src/orders/types.ts
@@ -39,6 +39,7 @@ export type OrderV2 = {
   clientSignature: string | null;
   makerAssetBundle: OpenSeaAssetBundle;
   takerAssetBundle: OpenSeaAssetBundle;
+  remainingQuantity: number;
 };
 
 export type FulfillmentDataResponse = {
@@ -116,6 +117,7 @@ export type SerializedOrderV2 = {
   client_signature: string | null;
   maker_asset_bundle: unknown;
   taker_asset_bundle: unknown;
+  remaining_quantity: number;
 };
 
 export type QueryCursors = {

--- a/src/orders/utils.ts
+++ b/src/orders/utils.ts
@@ -182,5 +182,6 @@ export const deserializeOrder = (order: SerializedOrderV2): OrderV2 => {
     clientSignature: order.client_signature,
     makerAssetBundle: assetBundleFromJSON(order.maker_asset_bundle),
     takerAssetBundle: assetBundleFromJSON(order.taker_asset_bundle),
+    remainingQuantity: order.remaining_quantity,
   };
 };

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -93,7 +93,7 @@ export class OpenSeaSDK {
 
     this.provider = provider;
     this._signerOrProvider = wallet ?? this.provider;
-
+    console.log(this._signerOrProvider);
     this.seaport_v1_5 = new Seaport(this._signerOrProvider, {
       overrides: { defaultConduitKey: OPENSEA_CONDUIT_KEY },
     });

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -93,6 +93,7 @@ export class OpenSeaSDK {
 
     this.provider = provider;
     this._signerOrProvider = wallet ?? this.provider;
+
     this.seaport_v1_5 = new Seaport(this._signerOrProvider, {
       overrides: { defaultConduitKey: OPENSEA_CONDUIT_KEY },
     });

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -93,7 +93,6 @@ export class OpenSeaSDK {
 
     this.provider = provider;
     this._signerOrProvider = wallet ?? this.provider;
-    console.log(this._signerOrProvider);
     this.seaport_v1_5 = new Seaport(this._signerOrProvider, {
       overrides: { defaultConduitKey: OPENSEA_CONDUIT_KEY },
     });

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -22,6 +22,7 @@ export const expectValidOrder = (order: OrderV2) => {
     "markedInvalid",
     "makerAssetBundle",
     "takerAssetBundle",
+    "remainingQuantity",
   ];
   for (const field of requiredFields) {
     expect(field in order).to.be.true;


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

We wanted to get unit price of the lowest listing (aka a "quote" of a given NFT asset from Opensea) and needed an easier way to access the quantity field for a given order, as the current price is given as a total rather than a unit price. 

For more details see: https://github.com/ProjectOpenSea/opensea-js/issues/1064

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
expose the "remaining_quantity" field from API. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
