### PR TITLE
Simplify isValidProtocol check

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -414,7 +414,7 @@ export const isTestChain = (chain: Chain): boolean => {
 };
 
 /**
- * Checks if a protocol address is valid.
+ * Returns if a protocol address is valid.
  * @param protocolAddress The protocol address
  */
 export const isValidProtocol = (protocolAddress: string): boolean => {
@@ -423,6 +423,16 @@ export const isValidProtocol = (protocolAddress: string): boolean => {
     (address) => ethers.utils.getAddress(address),
   );
   return validProtocolAddresses.includes(checkSumAddress);
+};
+
+/**
+ * Throws an error if the protocol address is not valid.
+ * @param protocolAddress The protocol address
+ */
+export const requireValidProtocol = (protocolAddress: string) => {
+  if (!isValidProtocol(protocolAddress)) {
+    throw new Error("Unsupported protocol");
+  }
 };
 
 /**


### PR DESCRIPTION
- DRY `isValidProtocol` by introducing `requireValidProtocol` that throws the consistent error
- Rename `_checkAccountIsAvailable` to `_requireAccountIsAvailable` to hint that an error will be thrown