### PR TITLE
Fix getting extraData in order fulfillment

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -705,10 +705,9 @@ export class OpenSeaSDK {
 
       // If the order is using offer protection, the extraData
       // must be included with the order to successfully fulfill.
-      const fulfillmentOrder =
-        result.fulfillment_data.transaction.input_data.orders[0];
-      if ("extraData" in fulfillmentOrder) {
-        extraData = (fulfillmentOrder as AdvancedOrder).extraData;
+      const inputData = result.fulfillment_data.transaction.input_data;
+      if ("orders" in inputData && "extraData" in inputData.orders[0]) {
+        extraData = (inputData.orders[0] as AdvancedOrder).extraData;
       }
 
       const signature = result.fulfillment_data.orders[0].signature;


### PR DESCRIPTION
extraData is only provided in an array of Advanced Orders, improves the guard

Fixes #1153

TODO need to add a local hardhat forked setup for an integration test to get varying valid orders (basic, advanced with protection, etc.) and fulfill them on the fork and ensure the tx is successful. might try to add this today.