### PR TITLE
Add eslint rule to restrict importing from "src"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,12 @@ module.exports = {
     "no-restricted-imports": [
       "error",
       {
-        patterns: ["src"],
+        patterns: [
+          {
+            group: ["src/**", "!src/*"],
+            message: "Please use relative import for `src` files.",
+          },
+        ],
       },
     ],
     curly: ["error"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,12 @@ module.exports = {
   ],
   rules: {
     "no-restricted-globals": ["error"].concat(restrictedGlobals),
+    "no-restricted-imports": [
+      "error",
+      {
+        patterns: ["src"],
+      },
+    ],
     curly: ["error"],
     "@typescript-eslint/no-unused-vars": [
       "error",

--- a/test/api/getOrders.spec.ts
+++ b/test/api/getOrders.spec.ts
@@ -1,7 +1,7 @@
 import "../utils/setup";
 import { expect } from "chai";
 import { suite, test } from "mocha";
-import { OrderSide } from "src/orders/types";
+import { OrderSide } from "../../src/orders/types";
 import {
   BAYC_CONTRACT_ADDRESS,
   BAYC_TOKEN_IDS,

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { OrderV2 } from "src/orders/types";
+import { OrderV2 } from "../../src/orders/types";
 
 export const expectValidOrder = (order: OrderV2) => {
   const requiredFields = [


### PR DESCRIPTION
Fixes issues like https://github.com/ProjectOpenSea/opensea-js/issues/1164 https://github.com/ProjectOpenSea/opensea-js/issues/1121

Example error with this rule added:
<img width="535" alt="Screenshot 2023-08-16 at 10 05 11 AM" src="https://github.com/ProjectOpenSea/opensea-js/assets/22116/5d3d2ae3-a931-4b03-a398-0372b4a7c7d6">
