### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Get started by [requesting an API key](https://docs.opensea.io/reference/api-key
 
 Happy seafaring! ⛵️
 
-## Table of Contentst
+## Table of Content
 
 [Quick Start Guide](developerDocs/quick-start.md)\
 [Getting Started Guide](developerDocs/getting-started.md)\

--- a/developerDocs/getting-started.md
+++ b/developerDocs/getting-started.md
@@ -61,9 +61,12 @@ The nice thing about the `Asset` type is that it unifies logic between fungibles
 Once you have an `Asset`, you can see how many any account owns, regardless of whether it's an ERC-20 token or a non-fungible good:
 
 ```typescript
+import { TokenStandard } from 'opensea-js/lib/types';
+
 const asset = {
   tokenAddress: "0x06012c8cf97bead5deae237070f9587f8e7a266d", // CryptoKitties
   tokenId: "1", // Token ID
+  tokenStandard: TokenStandard.ERC721, // Required in getBalance
 };
 
 const balance = await openseaSDK.getBalance({
@@ -71,7 +74,7 @@ const balance = await openseaSDK.getBalance({
   asset, // Asset
 });
 
-const ownsKitty = balance.greaterThan(0);
+const ownsKitty = !balance.isZero();
 ```
 
 ### Making Offers

--- a/developerDocs/getting-started.md
+++ b/developerDocs/getting-started.md
@@ -12,6 +12,7 @@ hidden: false
 - [Making Offers](#making-offers)
   - [Offer Limits](#offer-limits)
 - [Making Listings / Selling Items](#making-listings--selling-items)
+  - [Creating English Auctions](#creating-english-auctions)
 - [Fetching Orders](#fetching-orders)
 - [Buying Items](#buying-items)
 - [Accepting Offers](#accepting-offers)

--- a/developerDocs/getting-started.md
+++ b/developerDocs/getting-started.md
@@ -46,10 +46,22 @@ The `Asset` type is the minimal type you need for most marketplace actions. `Tok
 You can fetch an asset using the `OpenSeaAPI`, which will return an `OpenSeaAsset` for you (`OpenSeaAsset` extends `Asset`):
 
 ```TypeScript
+import { Chain } from "opensea-js";
+
+// Old deprecated way
 const asset: OpenSeaAsset = await openseaSDK.api.getAsset({
   tokenAddress, // string
   tokenId, // string | number | BigNumber | null
 })
+
+// New Multi-Chain query
+const nftKitty = await openseaSDK.api.getNFT(
+  Chain.Mainnet,
+  tokenAddress, // ex : '0x06012c8cf97bead5deae237070f9587f8e7a266d'
+  tokenId, // ex : '1'
+);
+
+console.log(nftKitty);
 ```
 
 Note that fungible ERC20 assets have `null` as their token id.

--- a/developerDocs/quick-start.md
+++ b/developerDocs/quick-start.md
@@ -36,7 +36,7 @@ const provider = new ethers.providers.JsonRpcProvider(
 
 const openseaSDK = new OpenSeaSDK(provider, {
   chain: Chain.Mainnet,
-  apiKey: YOUR_API_KEY,
+  apiKey: YOUR_API_KEY, // remove the api key if using testnets
 });
 ```
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -423,7 +423,7 @@ export class OpenSeaSDK {
    * Create a sell order to make a listing for a asset.
    * @param options
    * @param options.asset The asset to trade
-   * @param options.accountAddress  Address of the wallet making the buy order
+   * @param options.accountAddress  Address of the wallet making the sell order
    * @param options.startAmount Value of the listing at the start of the auction in units, not base units e.g. not wei, of the payment token (or WETH if no payment token address specified)
    * @param options.endAmount Value of the listing at the end of the auction. If specified, price will change linearly between startAmount and endAmount as time progresses.
    * @param options.quantity The number of assets to list (if fungible or semi-fungible). Defaults to 1.

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -858,8 +858,8 @@ export class OpenSeaSDK {
   /**
    * Get an account's balance of any Asset. This asset can be an ERC20, ERC1155, or ERC721.
    * @param options
-   * @param options.accountAddress Account address to check
-   * @param options.asset The Asset to check balance for
+   * @param options.accountAddress Account address to check.
+   * @param options.asset The Asset to check balance for. (asset.TokenStandard has to be defined)
    * @param retries How many times to retry if balance is 0. Defaults to 1.
    * @returns The balance of the asset for the account.
    *


### PR DESCRIPTION
Update the document for developer onboarding without errors

## Motivation

By following the getting started guide, a new user of the lib will encounter errors. (Missing `tokenStandard` in the first example, deprecated usage...).

## Solution

- Add the missing field in the getting-started guide
- Add an example of using the new multi-chain `getNFT` instead of old `getAsset`
- Update the jsdoc of the `getBalance` & `createSellOrder` method to make it more clear

ps : I kept the deprecated `getAsset`, maybe we should just delete it
