### PR TITLE
Fix _requireAccountIsAvailable, replace instanceof

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1084,12 +1084,16 @@ export class OpenSeaSDK {
   private async _requireAccountIsAvailable(accountAddress: string) {
     const accountAddressChecksummed = ethers.utils.getAddress(accountAddress);
     if (
-      (this._signerOrProvider instanceof Wallet &&
-        this._signerOrProvider.address === accountAddressChecksummed) ||
-      (this._signerOrProvider instanceof providers.JsonRpcProvider &&
-        (await this._signerOrProvider.listAccounts()).includes(
-          accountAddressChecksummed,
-        ))
+      (this._signerOrProvider.constructor.name === Wallet.name &&
+        (this._signerOrProvider as Wallet).address ===
+          accountAddressChecksummed) ||
+      (this._signerOrProvider.constructor.name ===
+        providers.JsonRpcProvider.name &&
+        (
+          await (
+            this._signerOrProvider as providers.JsonRpcProvider
+          ).listAccounts()
+        ).includes(accountAddressChecksummed))
     ) {
       return;
     }


### PR DESCRIPTION
## Motivation

In projects that are using esm modules instead of commonjs, `instanceof` does not return true when one instance of `Wallet` in client project is using `webpack://<project_name>/node_modules/@ethersproject/wallet/lib.esm/index.js` instead of `/node_modules/@ethersproject/wallet/lib/index.js`. While they are the same class from the same package, the js `instanceof` operation does not recognize them as matching.

## Solution

- Matches the name of the instantiation class of the `Wallet` instance passed into `OpenSeaSDK` constructor, and the `Wallet` class required inside opensea-js
- Casts instance to proper type before comparing address
