### PR TITLE
Remove schedule from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,5 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
-  ],
-  "schedule": ["before 9am on monday"]
+  ]
 }


### PR DESCRIPTION
Trying to automate automerge workflow, so we don't need to be on any specific schedule since passing PRs should be automerged
