### PR TITLE
Fix provider to use any provider that includes "listAccounts" (e.g. Web3Provider)

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1086,13 +1086,9 @@ export class OpenSeaSDK {
     const availableAccounts: string[] = [];
 
     if ("address" in this._signerOrProvider) {
-      availableAccounts.push((this._signerOrProvider as Wallet).address);
+      availableAccounts.push(this._signerOrProvider.address);
     } else if ("listAccounts" in this._signerOrProvider) {
-      availableAccounts.push(
-        ...(await (
-          this._signerOrProvider as providers.JsonRpcProvider
-        ).listAccounts()),
-      );
+      availableAccounts.push(...(await this._signerOrProvider.listAccounts()));
     }
 
     if (availableAccounts.includes(accountAddressChecksummed)) {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1082,25 +1082,21 @@ export class OpenSeaSDK {
    * @param accountAddress The account address to check is available.
    */
   private async _requireAccountIsAvailable(accountAddress: string) {
-    const availableAccounts: string[] = [];
     const accountAddressChecksummed = ethers.utils.getAddress(accountAddress);
+    const availableAccounts: string[] = [];
 
     if (this._signerOrProvider.constructor.name === Wallet.name) {
       availableAccounts.push((this._signerOrProvider as Wallet).address);
-      if (
-        (this._signerOrProvider as Wallet).address === accountAddressChecksummed
-      ) {
-        return;
-      }
     } else if ("listAccounts" in this._signerOrProvider) {
       availableAccounts.push(
         ...(await (
           this._signerOrProvider as providers.JsonRpcProvider
         ).listAccounts()),
       );
-      if (availableAccounts.includes(accountAddressChecksummed)) {
-        return;
-      }
+    }
+
+    if (availableAccounts.includes(accountAddressChecksummed)) {
+      return;
     }
 
     throw new Error(

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1085,7 +1085,7 @@ export class OpenSeaSDK {
     const accountAddressChecksummed = ethers.utils.getAddress(accountAddress);
     const availableAccounts: string[] = [];
 
-    if (this._signerOrProvider.constructor.name === Wallet.name) {
+    if ("address" in this._signerOrProvider) {
       availableAccounts.push((this._signerOrProvider as Wallet).address);
     } else if ("listAccounts" in this._signerOrProvider) {
       availableAccounts.push(

--- a/test/sdk/misc.spec.ts
+++ b/test/sdk/misc.spec.ts
@@ -71,21 +71,21 @@ suite("SDK: misc", () => {
   test("Should throw an error when using methods that need a provider or wallet with the accountAddress", async () => {
     const wallet = ethers.Wallet.createRandom();
     const accountAddress = wallet.address;
-    const expectedErrorMessage = `Specified accountAddress is not available through wallet or provider: ${accountAddress}. Accounts available: none`;
+    const expectedErrorMessage = `Specified accountAddress is not available through wallet or provider: ${accountAddress}`;
 
     /* eslint-disable @typescript-eslint/no-explicit-any */
     try {
       await client.wrapEth({ amountInEth: "0.1", accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
 
     try {
       await client.unwrapWeth({ amountInEth: "0.1", accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
 
     const asset = {} as any;
@@ -94,14 +94,14 @@ suite("SDK: misc", () => {
       await client.createBuyOrder({ asset, startAmount: 1, accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
 
     try {
       await client.createSellOrder({ asset, startAmount: 1, accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
 
     try {
@@ -114,7 +114,7 @@ suite("SDK: misc", () => {
       });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
 
     const order = {} as any;
@@ -123,14 +123,14 @@ suite("SDK: misc", () => {
       await client.fulfillOrder({ order, accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
 
     try {
       await client.cancelOrder({ order, accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
 
     try {
@@ -140,7 +140,7 @@ suite("SDK: misc", () => {
       });
       throw new Error("should have thrown");
     } catch (e: any) {
-      expect(e.message).to.equal(expectedErrorMessage);
+      expect(e.message).to.include(expectedErrorMessage);
     }
     /* eslint-enable @typescript-eslint/no-explicit-any */
   });

--- a/test/sdk/misc.spec.ts
+++ b/test/sdk/misc.spec.ts
@@ -71,7 +71,7 @@ suite("SDK: misc", () => {
   test("Should throw an error when using methods that need a provider or wallet with the accountAddress", async () => {
     const wallet = ethers.Wallet.createRandom();
     const accountAddress = wallet.address;
-    const expectedErrorMessage = `Specified accountAddress is not available through wallet or provider: ${accountAddress}`;
+    const expectedErrorMessage = `Specified accountAddress is not available through wallet or provider: ${accountAddress}. Accounts available: none`;
 
     /* eslint-disable @typescript-eslint/no-explicit-any */
     try {


### PR DESCRIPTION
During #1198 #1204 while trying to fix esm imports replacing `instanceof` to constructor name comparison changed how the prototype inheritance chain is compared, and not all providers that inherit the base `JsonRpcProvider` are now equally compared. 

This PR updates the comparison to see if the provider simply includes `listAccounts()`, which all base `JsonRpcProviders`  do. This should fix using `window.ethereum` as well, and improves the error message for more helpful debugging.

Fixes #1221