### PR TITLE
Rename `createSellOrder` to `createListing` and `createBuyOrder` to `createOffer`, keep aliases for backward compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 This is the JavaScript SDK for [OpenSea](https://opensea.io), the largest marketplace for NFTs.
 
-It allows developers to access the official orderbook, filter it, create buy orders (**offers**), create sell orders (**listings**), and complete trades programmatically.
+It allows developers to access the official orderbook, filter it, create listings and offers, and complete trades programmatically.
 
 Get started by [requesting an API key](https://docs.opensea.io/reference/api-keys) and instantiating your own OpenSea SDK instance. Then you can create orders off-chain or fulfill orders on-chain, and listen to events (like `ApproveAllAssets` or `WrapEth`) in the process.
 

--- a/developerDocs/advanced-use-cases.md
+++ b/developerDocs/advanced-use-cases.md
@@ -19,15 +19,15 @@ Interested in purchasing for users server-side or with a bot, scheduling future 
 
 ### Scheduling Future Listings
 
-You can create sell orders that aren't fulfillable until a future date. Just pass in a `listingTime` (a UTC timestamp in seconds) to your SDK instance:
+You can create listings that aren't fulfillable until a future date. Just pass in a `listingTime` (a UTC timestamp in seconds) to your SDK instance:
 
 ```typescript
-const order = await openseaSDK.createSellOrder({
-  tokenAddress,
-  tokenId,
+const listingTime = Math.round(Date.now() / 1000 + 60 * 60 * 24); // One day from now
+const order = await openseaSDK.createListing({
+  asset: { tokenAddress, tokenId },
   accountAddress,
   startAmount: 1,
-  listingTime: Math.round(Date.now() / 1000 + 60 * 60 * 24), // One day from now
+  listingTime,
 });
 ```
 
@@ -53,13 +53,15 @@ This will automatically approve the assets for trading and confirm the transacti
 Here's an example of listing the Genesis CryptoKitty for $100! No more needing to worry about the exchange rate:
 
 ```typescript
+// CryptoKitties
+const tokenAddress = "0x06012c8cf97bead5deae237070f9587f8e7a266d";
 // Token address for the DAI stablecoin, which is pegged to $1 USD
-const paymentTokenAddress = "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359";
+const paymentTokenAddress = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 
 // The units for `startAmount` and `endAmount` are now in DAI, so $100 USD
-const order = await openseaSDK.createSellOrder({
-  tokenAddress: "0x06012c8cf97bead5deae237070f9587f8e7a266d", // CryptoKitties
-  tokenId: "1", // Token ID
+const order = await openseaSDK.createListing({
+  tokenAddress,
+  tokenId: "1",
   accountAddress: OWNERS_WALLET_ADDRESS,
   startAmount: 100,
   paymentTokenAddress,
@@ -87,11 +89,14 @@ Here's an example of listing a Decentraland parcel for 10 ETH with a specific bu
 ```typescript
 // Address allowed to buy from you
 const buyerAddress = "0x123...";
+// Decentraland
+const tokenAddress = "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d";
+const tokenId =
+  "115792089237316195423570985008687907832853042650384256231655107562007036952461";
 
-const listing = await openseaSDK.createSellOrder({
-  tokenAddress: "0xf87e31492faf9a91b02ee0deaad50d51d56d5d4d", // Decentraland
-  tokenId:
-    "115792089237316195423570985008687907832853042650384256231655107562007036952461", // Token ID
+const listing = await openseaSDK.createListing({
+  tokenAddress,
+  tokenId,
   accountAddress: OWNERS_WALLET_ADDRESS,
   startAmount: 10,
   buyerAddress,

--- a/developerDocs/advanced-use-cases.md
+++ b/developerDocs/advanced-use-cases.md
@@ -44,7 +44,7 @@ await openseaSDK.fulfillOrder({
 })
 ```
 
-If the order is a sell order (`order.side === "ask"`), the taker is the _buyer_ and this will prompt the buyer to pay for the item(s) but send them to the `recipientAddress`. If the order is a buy order ( `"bid"`), the taker is the _seller_ but the bid amount be sent to the `recipientAddress`.
+If the order is a listing (sell order, `order.side === "ask"`), the taker is the _buyer_ and this will prompt the buyer to pay for the item(s) but send them to the `recipientAddress`. If the order is an offer (buy order, `"bid"`), the taker is the _seller_ but the bid amount be sent to the `recipientAddress`.
 
 This will automatically approve the assets for trading and confirm the transaction for sending them.
 

--- a/developerDocs/getting-started.md
+++ b/developerDocs/getting-started.md
@@ -31,7 +31,8 @@ Also see methods `getNFTsByCollection`, `getNFTsByContract`, and `getNFTsByAccou
 import { TokenStandard } from "opensea-js/lib/types";
 
 const asset = {
-  tokenAddress: "0x06012c8cf97bead5deae237070f9587f8e7a266d", // CryptoKitties
+  // CryptoKitties
+  tokenAddress: "0x06012c8cf97bead5deae237070f9587f8e7a266d",
   tokenId: "1",
   tokenStandard: TokenStandard.ERC721,
 };
@@ -51,16 +52,16 @@ const ownsKitty = balance.gt(0);
 const { tokenId, tokenAddress } = YOUR_ASSET;
 // The offerer's wallet address:
 const accountAddress = "0x1234...";
+// Value of the offer, in units of the payment token (or wrapped ETH if none is specified)
+const startAmount = 1.2;
 
-const offer = await openseaSDK.createBuyOrder({
+const offer = await openseaSDK.createOffer({
   asset: {
     tokenId,
     tokenAddress,
-    tokenStandard, // TokenStandard. If omitted, defaults to 'ERC721'. Other options include 'ERC20' and 'ERC1155'
   },
   accountAddress,
-  // Value of the offer, in units of the payment token (or wrapped ETH if none is specified):
-  startAmount: 1.2,
+  startAmount,
 });
 ```
 
@@ -72,14 +73,14 @@ Note: The total value of buy orders must not exceed 1000x wallet balance.
 
 ### Making Listings / Selling Items
 
-To sell an asset, call `createSellOrder`:
+To sell an asset, call `createListing`:
 
 ```typescript
 // Expire this auction one day from now.
-// Note that we convert from the JavaScript timestamp (milliseconds):
+// Note that we convert from the JavaScript timestamp (milliseconds) to seconds:
 const expirationTime = Math.round(Date.now() / 1000 + 60 * 60 * 24);
 
-const listing = await openseaSDK.createSellOrder({
+const listing = await openseaSDK.createListing({
   asset: {
     tokenId,
     tokenAddress,
@@ -103,10 +104,11 @@ To create an English Auction set `englishAuction` to `true`:
 ```typescript
 // Create an auction to receive Wrapped Ether (WETH). See note below.
 const paymentTokenAddress = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+const englishAuction = true;
+// The minimum amount to start the auction at, in normal units (e.g. ETH)
+const startAmount = 0;
 
-const startAmount = 0; // The minimum amount to sell for, in normal units (e.g. ETH)
-
-const auction = await openseaSDK.createSellOrder({
+const auction = await openseaSDK.createListing({
   asset: {
     tokenId,
     tokenAddress,
@@ -115,7 +117,7 @@ const auction = await openseaSDK.createSellOrder({
   startAmount,
   expirationTime,
   paymentTokenAddress,
-  englishAuction: true,
+  englishAuction,
 });
 ```
 

--- a/developerDocs/getting-started.md
+++ b/developerDocs/getting-started.md
@@ -69,7 +69,7 @@ When you make an offer on an item owned by an OpenSea user, **that user will aut
 
 #### Offer Limits
 
-Note: The total value of buy orders must not exceed 1000x wallet balance.
+Note: The total value of offers must not exceed 1000x wallet balance.
 
 ### Making Listings / Selling Items
 
@@ -146,7 +146,7 @@ const { orders, count } = await openseaSDK.api.getOrders(
 );
 ```
 
-Note that the listing price of an asset is equal to the `currentPrice` of the **lowest valid sell order** on the asset. Users can lower their listing price without invalidating previous sell orders, so all get shipped down until they're canceled, or one is fulfilled.
+Note that the listing price of an asset is equal to the `currentPrice` of the **lowest listing** on the asset. Users can lower their listing price without invalidating previous listing, so all get shipped down until they're canceled, or one is fulfilled.
 
 To learn more about signatures, makers, takers, listingTime vs createdTime and other kinds of order terminology, please read the [**Terminology Section**](https://docs.opensea.io/reference#terminology) of the API Docs.
 
@@ -154,7 +154,7 @@ The available API filters for the orders endpoint is documented in the `OrdersQu
 
 ### Buying Items
 
-To buy an item, you need to **fulfill a sell order**. To do that, it's just one call:
+To buy an item, you need to **fulfill a listing**. To do that, it's just one call:
 
 ```typescript
 const order = await openseaSDK.api.getOrder({ side: "ask", ... })
@@ -164,11 +164,11 @@ const transactionHash = await openseaSDK.fulfillOrder({ order, accountAddress })
 
 Note that the `fulfillOrder` promise resolves when the transaction has been confirmed and mined to the blockchain. To get the transaction hash before this happens, add an event listener (see [Listening to Events](#listening-to-events)) for the `TransactionCreated` event.
 
-If the order is a sell order (`order.side === "ask"`), the taker is the _buyer_ and this will prompt the buyer to pay for the item(s).
+If the order is a listing (sell order, `order.side === "ask"`), the taker is the _buyer_ and this will prompt the buyer to pay for the item(s).
 
 ### Accepting Offers
 
-Similar to fulfilling sell orders above, you need to fulfill a buy order on an item you own to receive the tokens in the offer.
+Similar to fulfilling listings above, you need to fulfill an offer (buy order) on an item you own to receive the tokens in the offer.
 
 ```typescript
 const order = await openseaSDK.api.getOrder({ side: "bid", ... })
@@ -176,4 +176,4 @@ const accountAddress = "0x..." // The owner's wallet address, also the taker
 await openseaSDK.fulfillOrder({ order, accountAddress })
 ```
 
-If the order is a buy order (`order.side === "bid"`), then the taker is the _owner_ and this will prompt the owner to exchange their item(s) for whatever is being offered in return. See [Listening to Events](#listening-to-events) below to respond to the setup transactions that occur the first time a user accepts a bid.
+If the order is an offer (buy order, `order.side === "bid"`), then the taker is the _owner_ and this will prompt the owner to exchange their item(s) for whatever is being offered in return. See [Listening to Events](#listening-to-events) below to respond to the setup transactions that occur the first time a user accepts a bid.

--- a/developerDocs/overview.md
+++ b/developerDocs/overview.md
@@ -9,7 +9,7 @@ hidden: false
 
 This is the JavaScript SDK for [OpenSea](https://opensea.io), the largest marketplace for NFTs.
 
-It allows developers to access the official orderbook, filter it, create buy orders (**offers**), create sell orders (**listings**), and complete trades programmatically.
+It allows developers to access the official orderbook, filter it, create offers and listings, and complete trades programmatically.
 
 Get started by [requesting an API key](https://docs.opensea.io/reference/api-keys) and instantiating your own OpenSea SDK instance. Then you can create orders off-chain or fulfill orders on-chain, and listen to events in the process.
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint:fix": "npm run eslint:check -- --fix",
     "postinstall": "husky install || exit 0",
     "lint": "concurrently \"npm run check-types\" \"npm run prettier:check\" \"npm run eslint:check\"",
+    "lint:fix": "npm run prettier:fix && npm run eslint:fix",
     "prepare": "npm run build",
     "prettier:check": "prettier --check .",
     "prettier:check:package.json": "prettier-package-json --list-different",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -38,7 +38,6 @@ import {
   ERC721__factory,
 } from "./typechain/contracts";
 import {
-  Asset,
   ComputedFees,
   EventData,
   EventType,
@@ -49,6 +48,8 @@ import {
   OrderSide,
   TokenStandard,
   OpenSeaFungibleToken,
+  AssetWithTokenStandard,
+  AssetWithTokenId,
 } from "./types";
 import {
   delay,
@@ -319,9 +320,23 @@ export class OpenSeaSDK {
   }
 
   /**
-   * Create a buy order to make an offer on an asset.
+   * Alias, deprecated, please update to using {@link createListing}.
+   * This method will be removed in the next major version of opensea-js.
+   * @deprecated
+   */
+  createSellOrder = this.createListing;
+
+  /**
+   * Alias, deprecated, please update to using {@link createOffer}.
+   * This method will be removed in the next major version of opensea-js.
+   * @deprecated
+   */
+  createBuyOrder = this.createOffer;
+
+  /**
+   * Create and submit an offer on an asset.
    * @param options
-   * @param options.asset The asset to trade
+   * @param options.asset The asset to trade. tokenAddress and tokenId must be defined.
    * @param options.accountAddress Address of the wallet making the buy order
    * @param options.startAmount Value of the offer in units, not base units e.g. not wei, of the payment token (or WETH if no payment token address specified)
    * @param options.quantity The number of assets to bid for (if fungible or semi-fungible). Defaults to 1.
@@ -336,7 +351,7 @@ export class OpenSeaSDK {
    * @throws Error if the startAmount is not greater than 0.
    * @throws Error if paymentTokenAddress is not WETH on anything other than Ethereum mainnet.
    */
-  public async createBuyOrder({
+  public async createOffer({
     asset,
     accountAddress,
     startAmount,
@@ -344,9 +359,9 @@ export class OpenSeaSDK {
     domain,
     salt,
     expirationTime,
-    paymentTokenAddress,
+    paymentTokenAddress = getWETHAddress(this.chain),
   }: {
-    asset: Asset;
+    asset: AssetWithTokenId;
     accountAddress: string;
     startAmount: BigNumberish;
     quantity?: BigNumberish;
@@ -356,11 +371,6 @@ export class OpenSeaSDK {
     paymentTokenAddress?: string;
   }): Promise<OrderV2> {
     await this._requireAccountIsAvailable(accountAddress);
-
-    if (!asset.tokenId) {
-      throw new Error("Asset must have a tokenId");
-    }
-    paymentTokenAddress = paymentTokenAddress ?? getWETHAddress(this.chain);
 
     const { nft } = await this.api.getNFT(
       this.chain,
@@ -422,9 +432,9 @@ export class OpenSeaSDK {
   }
 
   /**
-   * Create a sell order to make a listing for a asset.
+   * Create and submit a listing for an asset.
    * @param options
-   * @param options.asset The asset to trade
+   * @param options.asset The asset to trade. tokenAddress and tokenId must be defined.
    * @param options.accountAddress  Address of the wallet making the sell order
    * @param options.startAmount Value of the listing at the start of the auction in units, not base units e.g. not wei, of the payment token (or WETH if no payment token address specified)
    * @param options.endAmount Value of the listing at the end of the auction. If specified, price will change linearly between startAmount and endAmount as time progresses.
@@ -443,7 +453,7 @@ export class OpenSeaSDK {
    * @throws Error if the startAmount is not greater than 0.
    * @throws Error if paymentTokenAddress is not WETH on anything other than Ethereum mainnet.
    */
-  public async createSellOrder({
+  public async createListing({
     asset,
     accountAddress,
     startAmount,
@@ -457,7 +467,7 @@ export class OpenSeaSDK {
     buyerAddress,
     englishAuction,
   }: {
-    asset: Asset;
+    asset: AssetWithTokenId;
     accountAddress: string;
     startAmount: BigNumberish;
     endAmount?: BigNumberish;
@@ -471,10 +481,6 @@ export class OpenSeaSDK {
     englishAuction?: boolean;
   }): Promise<OrderV2> {
     await this._requireAccountIsAvailable(accountAddress);
-
-    if (!asset.tokenId) {
-      throw new Error("Asset must have a tokenId");
-    }
 
     const { nft } = await this.api.getNFT(
       this.chain,
@@ -551,7 +557,7 @@ export class OpenSeaSDK {
   }
 
   /**
-   * Create a offer (buy order) for a collection.
+   * Create and submit a collection offer.
    * @param options
    * @param options.collectionSlug Identifier for the collection.
    * @param options.accountAddress Address of the wallet making the offer.
@@ -645,6 +651,15 @@ export class OpenSeaSDK {
     return this.api.postCollectionOffer(order, collectionSlug);
   }
 
+  /**
+   * Fulfill a private order for a designated address.
+   * @param options
+   * @param options.order The order to fulfill
+   * @param options.accountAddress Address of the wallet taking the order.
+   * @param options.domain An optional domain to be hashed and included at the end of fulfillment calldata.
+   *                       This can be used for on-chain order attribution to assist with analytics.
+   * @returns Transaction hash of the order.
+   */
   private async fulfillPrivateOrder({
     order,
     accountAddress,
@@ -686,7 +701,7 @@ export class OpenSeaSDK {
   }
 
   /**
-   * Fulfill or "take" an order for an asset. The order can be either a buy or sell order.
+   * Fulfill an order for an asset. The order can be either a listing or an offer.
    * @param options
    * @param options.order The order to fulfill, a.k.a. "take"
    * @param options.accountAddress Address of the wallet taking the offer.
@@ -765,19 +780,31 @@ export class OpenSeaSDK {
     return transaction.hash;
   }
 
+  /**
+   * Cancel orders onchain, preventing them from being fulfilled.
+   * @param options
+   * @param options.orders The orders to cancel
+   * @param options.accountAddress The account address cancelling the orders.
+   * @param options.domain An optional domain to be hashed and included at the end of fulfillment calldata.
+   *                       This can be used for on-chain order attribution to assist with analytics.
+   * @returns Transaction hash of the order.
+   */
   private async cancelSeaportOrders({
     orders,
     accountAddress,
     domain,
-    protocolAddress,
+    protocolAddress = DEFAULT_SEAPORT_CONTRACT_ADDRESS,
   }: {
     orders: OrderComponents[];
     accountAddress: string;
     domain?: string;
     protocolAddress?: string;
   }): Promise<string> {
-    if (!protocolAddress) {
-      protocolAddress = DEFAULT_SEAPORT_CONTRACT_ADDRESS;
+    const checksummedProtocolAddress = ethers.utils.getAddress(protocolAddress);
+    if (checksummedProtocolAddress !== DEFAULT_SEAPORT_CONTRACT_ADDRESS) {
+      throw new Error(
+        `Only ${DEFAULT_SEAPORT_CONTRACT_ADDRESS} is currently supported for cancelling orders.`,
+      );
     }
 
     const transaction = await this.seaport_v1_5
@@ -872,7 +899,10 @@ export class OpenSeaSDK {
    * @throws Error if the token standard does not support balanceOf.
    */
   public async getBalance(
-    { accountAddress, asset }: { accountAddress: string; asset: Asset },
+    {
+      accountAddress,
+      asset,
+    }: { accountAddress: string; asset: AssetWithTokenStandard },
     retries = 1,
   ): Promise<BigNumber> {
     try {
@@ -1084,7 +1114,6 @@ export class OpenSeaSDK {
 
   /**
    * Throws an error if an account is not available through the provider.
-   *
    * @param accountAddress The account address to check is available.
    */
   private async _requireAccountIsAvailable(accountAddress: string) {
@@ -1108,6 +1137,12 @@ export class OpenSeaSDK {
     );
   }
 
+  /**
+   * Wait for a transaction to confirm and log the success or failure.
+   * @param transactionHash The transaction hash to wait for.
+   * @param event The event type to log.
+   * @param description The description of the transaction.
+   */
   private async _confirmTransaction(
     transactionHash: string,
     event: EventType,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -154,7 +154,7 @@ export class OpenSeaSDK {
 
   /**
    * Wrap ETH into WETH.
-   * W-ETH is needed for placing buy orders (making offers).
+   * W-ETH is needed for making offers.
    * @param options
    * @param options.amountInEth Amount of ether to wrap
    * @param options.accountAddress Address of the user's wallet containing the ether
@@ -337,7 +337,7 @@ export class OpenSeaSDK {
    * Create and submit an offer on an asset.
    * @param options
    * @param options.asset The asset to trade. tokenAddress and tokenId must be defined.
-   * @param options.accountAddress Address of the wallet making the buy order
+   * @param options.accountAddress Address of the wallet making the offer.
    * @param options.startAmount Value of the offer in units, not base units e.g. not wei, of the payment token (or WETH if no payment token address specified)
    * @param options.quantity The number of assets to bid for (if fungible or semi-fungible). Defaults to 1.
    * @param options.domain An optional domain to be hashed and included in the first four bytes of the random salt.
@@ -435,7 +435,7 @@ export class OpenSeaSDK {
    * Create and submit a listing for an asset.
    * @param options
    * @param options.asset The asset to trade. tokenAddress and tokenId must be defined.
-   * @param options.accountAddress  Address of the wallet making the sell order
+   * @param options.accountAddress  Address of the wallet making the listing
    * @param options.startAmount Value of the listing at the start of the auction in units, not base units e.g. not wei, of the payment token (or WETH if no payment token address specified)
    * @param options.endAmount Value of the listing at the end of the auction. If specified, price will change linearly between startAmount and endAmount as time progresses.
    * @param options.quantity The number of assets to list (if fungible or semi-fungible). Defaults to 1.

--- a/src/types.ts
+++ b/src/types.ts
@@ -265,6 +265,24 @@ export interface Asset {
 }
 
 /**
+ * Generic Blockchain Asset, with tokenId required.
+ * @category API Models
+ */
+export interface AssetWithTokenId extends Asset {
+  /** The asset's token ID */
+  tokenId: string;
+}
+
+/**
+ * Generic Blockchain Asset, with tokenStandard required.
+ * @category API Models
+ */
+export interface AssetWithTokenStandard extends Asset {
+  /** The token standard (e.g. "ERC721") for this asset */
+  tokenStandard: TokenStandard;
+}
+
+/**
  * Annotated asset contract with OpenSea metadata
  */
 export interface OpenSeaAssetContract extends OpenSeaFees {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -308,7 +308,7 @@ export const hasErrorCode = (error: unknown): error is ErrorWithCode => {
   return !!untypedError.code;
 };
 
-export const getAssetItemType = (tokenStandard?: TokenStandard) => {
+export const getAssetItemType = (tokenStandard: TokenStandard) => {
   switch (tokenStandard) {
     case "ERC20":
       return ItemType.ERC20;

--- a/test/integration/postOrder.spec.ts
+++ b/test/integration/postOrder.spec.ts
@@ -30,7 +30,6 @@ suite("SDK: order posting", () => {
     // Test using alias for backwards compat, this can be removed when createBuyOrder is removed.
     const orderUsingAlias = await sdk.createBuyOrder(offer);
     expectValidOrder(orderUsingAlias);
-    expect(orderUsingAlias).to.deep.equal(order);
   });
 
   test("Post Offer - Polygon", async () => {
@@ -63,7 +62,6 @@ suite("SDK: order posting", () => {
     // Test using alias for backwards compat, this can be removed when createSellOrder is removed.
     const orderUsingAlias = await sdk.createSellOrder(listing);
     expectValidOrder(orderUsingAlias);
-    expect(orderUsingAlias).to.deep.equal(order);
   });
 
   test("Post English Auction Listing - Mainnet", async function () {

--- a/test/integration/postOrder.spec.ts
+++ b/test/integration/postOrder.spec.ts
@@ -16,7 +16,7 @@ import { OFFER_AMOUNT } from "../utils/constants";
 import { expectValidOrder } from "../utils/utils";
 
 suite("SDK: order posting", () => {
-  test("Post Buy Order - Mainnet", async () => {
+  test("Post Offer - Mainnet", async () => {
     const offer = {
       accountAddress: walletAddress,
       startAmount: +OFFER_AMOUNT,
@@ -33,7 +33,7 @@ suite("SDK: order posting", () => {
     expect(orderUsingAlias).to.deep.equal(order);
   });
 
-  test("Post Buy Order - Polygon", async () => {
+  test("Post Offer - Polygon", async () => {
     const offer = {
       accountAddress: walletAddress,
       startAmount: +OFFER_AMOUNT,
@@ -46,7 +46,7 @@ suite("SDK: order posting", () => {
     expectValidOrder(order);
   });
 
-  test("Post Sell Order - Mainnet", async function () {
+  test("Post Listing - Mainnet", async function () {
     if (!TOKEN_ADDRESS_MAINNET || !TOKEN_ID_MAINNET) {
       this.skip();
     }
@@ -66,7 +66,7 @@ suite("SDK: order posting", () => {
     expect(orderUsingAlias).to.deep.equal(order);
   });
 
-  test("Post Auction Sell Order - Mainnet", async function () {
+  test("Post English Auction Listing - Mainnet", async function () {
     if (!TOKEN_ADDRESS_MAINNET || !TOKEN_ID_MAINNET) {
       this.skip();
     }
@@ -95,7 +95,7 @@ suite("SDK: order posting", () => {
     }
   });
 
-  test("Post Sell Order - Polygon", async function () {
+  test("Post Listing - Polygon", async function () {
     if (!TOKEN_ADDRESS_POLYGON || !TOKEN_ID_POLYGON) {
       this.skip();
     }

--- a/test/integration/postOrder.spec.ts
+++ b/test/integration/postOrder.spec.ts
@@ -17,7 +17,7 @@ import { expectValidOrder } from "../utils/utils";
 
 suite("SDK: order posting", () => {
   test("Post Buy Order - Mainnet", async () => {
-    const buyOrder = {
+    const offer = {
       accountAddress: walletAddress,
       startAmount: +OFFER_AMOUNT,
       asset: {
@@ -25,12 +25,16 @@ suite("SDK: order posting", () => {
         tokenId: "2288",
       },
     };
-    const order = await sdk.createBuyOrder(buyOrder);
+    const order = await sdk.createOffer(offer);
     expectValidOrder(order);
+    // Test using alias for backwards compat, this can be removed when createBuyOrder is removed.
+    const orderUsingAlias = await sdk.createBuyOrder(offer);
+    expectValidOrder(orderUsingAlias);
+    expect(orderUsingAlias).to.deep.equal(order);
   });
 
   test("Post Buy Order - Polygon", async () => {
-    const buyOrder = {
+    const offer = {
       accountAddress: walletAddress,
       startAmount: +OFFER_AMOUNT,
       asset: {
@@ -38,7 +42,7 @@ suite("SDK: order posting", () => {
         tokenId: "2288",
       },
     };
-    const order = await sdk.createBuyOrder(buyOrder);
+    const order = await sdk.createOffer(offer);
     expectValidOrder(order);
   });
 
@@ -46,7 +50,7 @@ suite("SDK: order posting", () => {
     if (!TOKEN_ADDRESS_MAINNET || !TOKEN_ID_MAINNET) {
       this.skip();
     }
-    const sellOrder = {
+    const listing = {
       accountAddress: walletAddress,
       startAmount: LISTING_AMOUNT,
       asset: {
@@ -54,15 +58,19 @@ suite("SDK: order posting", () => {
         tokenId: TOKEN_ID_MAINNET as string,
       },
     };
-    const order = await sdk.createSellOrder(sellOrder);
+    const order = await sdk.createListing(listing);
     expectValidOrder(order);
+    // Test using alias for backwards compat, this can be removed when createSellOrder is removed.
+    const orderUsingAlias = await sdk.createSellOrder(listing);
+    expectValidOrder(orderUsingAlias);
+    expect(orderUsingAlias).to.deep.equal(order);
   });
 
   test("Post Auction Sell Order - Mainnet", async function () {
     if (!TOKEN_ADDRESS_MAINNET || !TOKEN_ID_MAINNET) {
       this.skip();
     }
-    const sellOrder = {
+    const listing = {
       accountAddress: walletAddress,
       startAmount: LISTING_AMOUNT,
       asset: {
@@ -72,7 +80,7 @@ suite("SDK: order posting", () => {
       englishAuction: true,
     };
     try {
-      const order = await sdk.createSellOrder(sellOrder);
+      const order = await sdk.createListing(listing);
       expectValidOrder(order);
       expect(order.protocolData.parameters.zone.toLowerCase()).to.equal(
         ENGLISH_AUCTION_ZONE_MAINNETS,
@@ -91,7 +99,7 @@ suite("SDK: order posting", () => {
     if (!TOKEN_ADDRESS_POLYGON || !TOKEN_ID_POLYGON) {
       this.skip();
     }
-    const sellOrder = {
+    const listing = {
       accountAddress: walletAddress,
       startAmount: +LISTING_AMOUNT * 1_000_000,
       asset: {
@@ -99,7 +107,7 @@ suite("SDK: order posting", () => {
         tokenId: TOKEN_ID_POLYGON,
       },
     };
-    const order = await sdkPolygon.createSellOrder(sellOrder);
+    const order = await sdkPolygon.createListing(listing);
     expectValidOrder(order);
   });
 

--- a/test/sdk/misc.spec.ts
+++ b/test/sdk/misc.spec.ts
@@ -147,27 +147,27 @@ suite("SDK: misc", () => {
 
   describe("decodeTokenIds", () => {
     it('should return ["*"] when given "*" as input', () => {
-      expect(decodeTokenIds("*")).deep.equal(["*"]);
+      expect(decodeTokenIds("*")).to.deep.equal(["*"]);
     });
 
     it("should correctly decode a single number", () => {
-      expect(decodeTokenIds("123")).deep.equal(["123"]);
+      expect(decodeTokenIds("123")).to.deep.equal(["123"]);
     });
 
     it("should correctly decode multiple comma-separated numbers", () => {
-      expect(decodeTokenIds("1,2,3,4")).deep.equal(["1", "2", "3", "4"]);
+      expect(decodeTokenIds("1,2,3,4")).to.deep.equal(["1", "2", "3", "4"]);
     });
 
     it("should correctly decode a single number", () => {
-      expect(decodeTokenIds("10:10")).deep.equal(["10"]);
+      expect(decodeTokenIds("10:10")).to.deep.equal(["10"]);
     });
 
     it("should correctly decode a range of numbers", () => {
-      expect(decodeTokenIds("5:8")).deep.equal(["5", "6", "7", "8"]);
+      expect(decodeTokenIds("5:8")).to.deep.equal(["5", "6", "7", "8"]);
     });
 
     it("should correctly decode multiple ranges of numbers", () => {
-      expect(decodeTokenIds("1:3,7:9")).deep.equal([
+      expect(decodeTokenIds("1:3,7:9")).to.deep.equal([
         "1",
         "2",
         "3",
@@ -178,14 +178,20 @@ suite("SDK: misc", () => {
     });
 
     it("should correctly decode a mix of single numbers and ranges", () => {
-      expect(decodeTokenIds("1,3:5,8")).deep.equal(["1", "3", "4", "5", "8"]);
+      expect(decodeTokenIds("1,3:5,8")).to.deep.equal([
+        "1",
+        "3",
+        "4",
+        "5",
+        "8",
+      ]);
     });
 
     it("should throw an error for invalid input format", () => {
-      expect(() => decodeTokenIds("1:3:5,8")).throw(
+      expect(() => decodeTokenIds("1:3:5,8")).to.throw(
         "Invalid input format. Expected a valid comma-separated list of numbers and ranges.",
       );
-      expect(() => decodeTokenIds("1;3:5,8")).throw(
+      expect(() => decodeTokenIds("1;3:5,8")).to.throw(
         "Invalid input format. Expected a valid comma-separated list of numbers and ranges.",
       );
     });

--- a/test/sdk/misc.spec.ts
+++ b/test/sdk/misc.spec.ts
@@ -91,14 +91,14 @@ suite("SDK: misc", () => {
     const asset = {} as any;
 
     try {
-      await client.createBuyOrder({ asset, startAmount: 1, accountAddress });
+      await client.createOffer({ asset, startAmount: 1, accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
       expect(e.message).to.include(expectedErrorMessage);
     }
 
     try {
-      await client.createSellOrder({ asset, startAmount: 1, accountAddress });
+      await client.createListing({ asset, startAmount: 1, accountAddress });
       throw new Error("should have thrown");
     } catch (e: any) {
       expect(e.message).to.include(expectedErrorMessage);


### PR DESCRIPTION
renames:
 - `createSellOrder` to `createListing`
 - `createBuyOrder` to `createOffer`
 
creates deprecated aliases for backward compact

misc cleanup and fixes:
 - add more typedocs
 - improve type for `Asset` when tokenId or tokenStandard is required