### PR TITLE
fix(sdk): allow apiBaseUrl overwrite

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -105,9 +105,13 @@ export class OpenSeaAPI {
     this.apiKey = config.apiKey;
     this.chain = config.chain ?? Chain.Mainnet;
 
-    this.apiBaseUrl = isTestChain(this.chain)
-      ? API_BASE_TESTNET
-      : API_BASE_MAINNET;
+    if (config.apiBaseUrl) {
+      this.apiBaseUrl = config.apiBaseUrl;
+    } else {
+      this.apiBaseUrl = isTestChain(this.chain)
+        ? API_BASE_TESTNET
+        : API_BASE_MAINNET;
+    }
 
     // Debugging: default to nothing
     this.logger = logger ?? ((arg: string) => arg);


### PR DESCRIPTION
# Bug

OpenSeaSDK does not use the `apiBaseUrl` parameter in the `apiConfig`, instead overwrites it with the default parameters.

The PR allows to again overwrite the base url as the user pleases.