### PR TITLE
Add zone parameter to createOffer function for SignedZone support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensea-js",
-  "version": "7.1.10",
+  "version": "7.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensea-js",
-      "version": "7.1.10",
+      "version": "7.1.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const API_BASE_MAINNET = "https://api.opensea.io";
 export const API_BASE_TESTNET = "https://testnets-api.opensea.io";
 
 export const DEFAULT_ZONE = ZeroAddress;
+export const SIGNED_ZONE = "0x000056f7000000ece9003ca63978907a00ffd100";
 export const ENGLISH_AUCTION_ZONE_MAINNETS =
   "0x110b2b128a9ed1be5ef3232d8e4e41640df5c2cd";
 export const ENGLISH_AUCTION_ZONE_TESTNETS =

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -27,6 +27,7 @@ import { CollectionOffer, Listing, NFT, Order } from "./api/types";
 import {
   INVERSE_BASIS_POINT,
   DEFAULT_ZONE,
+  SIGNED_ZONE,
   ENGLISH_AUCTION_ZONE_MAINNETS,
   ENGLISH_AUCTION_ZONE_TESTNETS,
 } from "./constants";
@@ -342,6 +343,7 @@ export class OpenSeaSDK {
    * @param options.expirationTime Expiration time for the order, in UTC seconds
    * @param options.paymentTokenAddress ERC20 address for the payment token in the order. If unspecified, defaults to WETH
    * @param options.excludeOptionalCreatorFees If true, optional creator fees will be excluded from the offer. Default: false.
+   * @param options.zone The zone to use for the order. If unspecified, defaults to SIGNED_ZONE.
    * @returns The {@link OrderV2} that was created.
    *
    * @throws Error if the asset does not contain a token id.
@@ -359,6 +361,7 @@ export class OpenSeaSDK {
     expirationTime,
     paymentTokenAddress = getWETHAddress(this.chain),
     excludeOptionalCreatorFees = false,
+    zone = SIGNED_ZONE, // Add the zone parameter with default value SIGNED_ZONE
   }: {
     asset: AssetWithTokenId;
     accountAddress: string;
@@ -369,6 +372,7 @@ export class OpenSeaSDK {
     expirationTime?: BigNumberish;
     paymentTokenAddress?: string;
     excludeOptionalCreatorFees?: boolean;
+    zone?: string; // Add the zone type
   }): Promise<OrderV2> {
     await this._requireAccountIsAvailable(accountAddress);
 
@@ -394,7 +398,6 @@ export class OpenSeaSDK {
       excludeOptionalCreatorFees,
     });
 
-    let zone = DEFAULT_ZONE;
     if (collection.requiredZone) {
       zone = collection.requiredZone;
     }


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
--> adding SIGNED_ZONE to be able to cancel id offers created using the sdk.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
--> added  export const SIGNED_ZONE = "0x000056f7000000ece9003ca63978907a00ffd100" and pushed to createOffer()
