### PR TITLE
support for collection with 0% Opensea fee

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -305,10 +305,12 @@ export class OpenSeaSDK {
     if (seller) {
       considerationItems.push(getConsiderationItem(sellerBasisPoints, seller));
     }
-    for (const fee of collectionFees) {
-      considerationItems.push(
-        getConsiderationItem(basisPointsForFee(fee), fee.recipient),
-      );
+    if (collectionFeesBasisPoints > 0) {
+      for (const fee of collectionFees) {
+        considerationItems.push(
+          getConsiderationItem(basisPointsForFee(fee), fee.recipient),
+        );
+      }
     }
     return considerationItems;
   }


### PR DESCRIPTION
## Motivation

Fix the issue where collections with zero fees are not handled correctly, causing unnecessary errors.

## Solution

Filter out zero-value fees and add a conditional check to process fees only when they are greater than zero.

Related issue: [#1531](https://github.com/ProjectOpenSea/opensea-js/issues/1531)