### PR TITLE
Updated Price type

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -131,11 +131,9 @@ export type CollectionOffer = Required<Pick<Offer, "criteria">> & Offer;
  * @category API Models
  */
 export type Price = {
-  current: {
-    currency: string;
-    decimals: number;
-    value: string;
-  };
+  currency: string;
+  decimals: number;
+  value: string;
 };
 
 /**

--- a/test/integration/getListingsAndOffers.spec.ts
+++ b/test/integration/getListingsAndOffers.spec.ts
@@ -65,6 +65,10 @@ suite("SDK: getBestOffer", () => {
     const tokenId = 1;
     const response = await sdk.api.getBestOffer(slug, tokenId);
 
+    assert.isString(response.price.currency, "Currency should be a string");
+    assert.isNumber(response.price.decimals, "Decimals should be a number");
+    assert.isString(response.price.value, "Price value should be a string");
+
     assert(response, "Response should not be null");
     assert(response.order_hash, "Order hash should not be null");
     assert(response.chain, "Chain should not be null");


### PR DESCRIPTION
Updated Price type (mismatch with API response) and added a few asserts examples for price in "BestOffer"

## Motivation

When implementing "opensea-js" package, I can't use the Price type. The API response doesn't contain a "current" field.

## Solution

Updated the type, removed the "current" level. Also added a few asserts in the unit test to validate the format of the API call.
Also, maybe it's a nice recommendation to include "zod" so you can validate API responses against a schema during tests