### PR TITLE
minor docstring fixups

### DIFF
--- a/developerDocs/getting-started.md
+++ b/developerDocs/getting-started.md
@@ -116,7 +116,7 @@ const offer = await openseaSDK.createCollectionOffer({
 
 #### Creating English Auctions
 
-English Auctions are auctions that start at a small amount (we recommend even doing 0!) and increase with every bid. At expiration time, the item sells to the highest bidder.
+English Auctions are auctions that start at a small amount (we recommend even using 0!) and increase with every bid. At expiration time, the item sells to the highest bidder.
 
 To create an English Auction set `englishAuction` to `true`:
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -437,7 +437,7 @@ export class OpenSeaSDK {
    * @param options.buyerAddress Optional address that's allowed to purchase this item. If specified, no other address will be able to take the order, unless its value is the null address.
    * @param options.englishAuction If true, the order will be listed as an English auction.
    * @param options.excludeOptionalCreatorFees If true, optional creator fees will be excluded from the listing. Default: false.
-   * @param options.zone The zone to use for the order.  For order protection, pass SIGNED_ZONE. If unspecified, defaults to no zone.
+   * @param options.zone The zone to use for the order. For order protection, pass SIGNED_ZONE. If unspecified, defaults to no zone.
    * @returns The {@link OrderV2} that was created.
    *
    * @throws Error if the asset does not contain a token id.


### PR DESCRIPTION
### Description

**developerDocs/getting-started.md**
`we recommend even doing 0!` - `we recommend even using 0!` -- _`Using` more accurately describes setting a value for a parameter, while `doing` refers more to performing an action. When it comes to numerical values, `using` is more idiomatic and technically correct._

**src/sdk.ts**
`order.  For order `- `order. For order` -- _deleted double space_