### PR TITLE
Add Shape to Chain enum

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -169,8 +169,6 @@ export enum Chain {
   SaigonTestnet = "saigon_testnet",
   /** Abstract Testnet */
   AbstractTestnet = "abstract_testnet",
-  /** Shape Testnet */
-  ShapeTestnet = "shape_testnet",
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,8 @@ export enum Chain {
   Ronin = "ronin",
   /** Abstract */
   Abstract = "abstract",
+  /** Shape */
+  Shape = "shape",
   // Testnet Chains
   // ⚠️NOTE: When adding to this list, also add to the util function `isTestChain`
   /** Sepolia */
@@ -167,6 +169,8 @@ export enum Chain {
   SaigonTestnet = "saigon_testnet",
   /** Abstract Testnet */
   AbstractTestnet = "abstract_testnet",
+  /** Shape Testnet */
+  ShapeTestnet = "shape_testnet",
 }
 
 /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -231,6 +231,10 @@ export const getChainId = (chain: Chain) => {
       return "2741";
     case Chain.AbstractTestnet:
       return "11124";
+    case Chain.Shape:
+      return "360";
+    case Chain.ShapeTestnet:
+      return "11011";
     default:
       throw new Error(`Unknown chainId for ${chain}`);
   }
@@ -295,6 +299,10 @@ export const getWETHAddress = (chain: Chain) => {
       return "0x3439153eb7af838ad19d56e1571fbd09333c2809";
     case Chain.AbstractTestnet:
       return "0x9edcde0257f2386ce177c3a7fcdd97787f0d841d";
+    case Chain.Shape:
+      return "0x4200000000000000000000000000000000000006";
+    case Chain.ShapeTestnet:
+      return "0x48A9B22b80F566E88f0f1DcC90Ea15A8A3bAE8a4";
     default:
       throw new Error(`Unknown WETH address for ${chain}`);
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -371,6 +371,7 @@ export const isTestChain = (chain: Chain): boolean => {
     case Chain.FlowTestnet:
     case Chain.SaigonTestnet:
     case Chain.AbstractTestnet:
+    case Chain.ShapeTestnet:
       return true;
     default:
       return false;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -233,8 +233,6 @@ export const getChainId = (chain: Chain) => {
       return "11124";
     case Chain.Shape:
       return "360";
-    case Chain.ShapeTestnet:
-      return "11011";
     default:
       throw new Error(`Unknown chainId for ${chain}`);
   }
@@ -301,8 +299,6 @@ export const getWETHAddress = (chain: Chain) => {
       return "0x9edcde0257f2386ce177c3a7fcdd97787f0d841d";
     case Chain.Shape:
       return "0x4200000000000000000000000000000000000006";
-    case Chain.ShapeTestnet:
-      return "0x48A9B22b80F566E88f0f1DcC90Ea15A8A3bAE8a4";
     default:
       throw new Error(`Unknown WETH address for ${chain}`);
   }
@@ -371,7 +367,6 @@ export const isTestChain = (chain: Chain): boolean => {
     case Chain.FlowTestnet:
     case Chain.SaigonTestnet:
     case Chain.AbstractTestnet:
-    case Chain.ShapeTestnet:
       return true;
     default:
       return false;


### PR DESCRIPTION

## Motivation

Add support for Shape Network

Official Website: https://shape.network/ 

Token: ETH
 

Shape is a creator-focused EVM-equivalent blockchain. Shape creators receive back a portion of the gas spent by users using a concept called “[gasback](https://docs.shape.network/documentation/building-on-shape/gasback).”

 

The Shape network is compatible with EVM wallets, and uses ETH bridged to Shape.

## Solution

Add Shape and testnet to Chain as well as util functions getChainId and getWETHAddress
