### PR TITLE
Use stable version for Coveralls GitHub Action

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm run coverage-report
 
       - name: Upload code coverage
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->
Replaced `coverallsapp/github-action@master` with `@v2` to use a stable, versioned release.

Using `master` is discouraged as it may lead to unexpected behavior due to upstream changes. Pinning to a specific version (`v2`) ensures stability and reproducibility in CI.

Official v2 release: https://github.com/coverallsapp/github-action/releases/tag/v2


