### PR TITLE
feat: add validateOrderOnchain method for Seaport integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensea-js",
-  "version": "7.1.22",
+  "version": "7.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensea-js",
-      "version": "7.1.22",
+      "version": "7.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "7.2.0",
+  "version": "7.2.1",
   "description": "TypeScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1243,6 +1243,46 @@ export class OpenSeaSDK {
   }
 
   /**
+   * Validates an order onchain using Seaport's validate() method. This submits the order onchain
+   * and pre-validates the order using Seaport, which makes it cheaper to fulfill since a signature
+   * is not needed to be verified during fulfillment for the order, but is not strictly required
+   * and the alternative is orders can be submitted to the API for free instead of sent onchain.
+   * @param order Order to validate onchain
+   * @param accountAddress Address of the wallet that will pay the gas to validate the order
+   * @param domain An optional domain to be hashed and included at the end of fulfillment calldata.  This can be used for on-chain order attribution to assist with analytics.
+   * @returns Transaction hash of the validation transaction
+   *
+   * @throws Error if the accountAddress is not available through wallet or provider.
+   * @throws Error if the order's protocol address is not supported by OpenSea. See {@link isValidProtocol}.
+   */
+  public async validateOrderOnchain(
+    order: OrderV2,
+    accountAddress: string,
+    domain?: string,
+  ) {
+    await this._requireAccountIsAvailable(accountAddress);
+    requireValidProtocol(order.protocolAddress);
+
+    this._dispatch(EventType.ApproveOrder, {
+      orderV2: order,
+      accountAddress,
+    });
+
+    const seaport = this.getSeaport(order.protocolAddress);
+    const transaction = await seaport
+      .validate([order.protocolData], accountAddress, domain)
+      .transact();
+
+    await this._confirmTransaction(
+      transaction.hash,
+      EventType.ApproveOrder,
+      "Validating order onchain",
+    );
+
+    return transaction.hash;
+  }
+
+  /**
    * Compute the `basePrice` and `endPrice` parameters to be used to price an order.
    * Also validates the expiration time and auction type.
    * @param tokenAddress Address of the ERC-20 token to use for trading. Use the null address for ETH.

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1249,17 +1249,12 @@ export class OpenSeaSDK {
    * and the alternative is orders can be submitted to the API for free instead of sent onchain.
    * @param order Order to validate onchain
    * @param accountAddress Address of the wallet that will pay the gas to validate the order
-   * @param domain An optional domain to be hashed and included at the end of fulfillment calldata.  This can be used for on-chain order attribution to assist with analytics.
    * @returns Transaction hash of the validation transaction
    *
    * @throws Error if the accountAddress is not available through wallet or provider.
    * @throws Error if the order's protocol address is not supported by OpenSea. See {@link isValidProtocol}.
    */
-  public async validateOrderOnchain(
-    order: OrderV2,
-    accountAddress: string,
-    domain?: string,
-  ) {
+  public async validateOrderOnchain(order: OrderV2, accountAddress: string) {
     await this._requireAccountIsAvailable(accountAddress);
     requireValidProtocol(order.protocolAddress);
 
@@ -1269,11 +1264,9 @@ export class OpenSeaSDK {
     });
 
     const seaport = this.getSeaport(order.protocolAddress);
-    const transaction = domain
-      ? await seaport
-          .validate([order.protocolData], accountAddress, domain)
-          .transact()
-      : await seaport.validate([order.protocolData], accountAddress).transact();
+    const transaction = await seaport
+      .validate([order.protocolData], accountAddress)
+      .transact();
 
     await this._confirmTransaction(
       transaction.hash,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1269,9 +1269,11 @@ export class OpenSeaSDK {
     });
 
     const seaport = this.getSeaport(order.protocolAddress);
-    const transaction = await seaport
-      .validate([order.protocolData], accountAddress, domain)
-      .transact();
+    const transaction = domain
+      ? await seaport
+          .validate([order.protocolData], accountAddress, domain)
+          .transact()
+      : await seaport.validate([order.protocolData], accountAddress).transact();
 
     await this._confirmTransaction(
       transaction.hash,

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -382,6 +382,7 @@ export class OpenSeaSDK {
     paymentTokenAddress = getOfferPaymentToken(this.chain),
     excludeOptionalCreatorFees = true,
     zone = getSignedZone(this.chain),
+    submitOrder = true,
   }: {
     asset: AssetWithTokenId;
     accountAddress: string;
@@ -393,6 +394,7 @@ export class OpenSeaSDK {
     paymentTokenAddress?: string;
     excludeOptionalCreatorFees?: boolean;
     zone?: string;
+    submitOrder?: boolean;
   }): Promise<OrderV2> {
     await this._requireAccountIsAvailable(accountAddress);
 
@@ -445,11 +447,15 @@ export class OpenSeaSDK {
     );
     const order = await executeAllActions();
 
-    return this.api.postOrder(order, {
-      protocol: "seaport",
-      protocolAddress: DEFAULT_SEAPORT_CONTRACT_ADDRESS,
-      side: OrderSide.OFFER,
-    });
+    if (submitOrder) {
+      return this.api.postOrder(order, {
+        protocol: "seaport",
+        protocolAddress: DEFAULT_SEAPORT_CONTRACT_ADDRESS,
+        side: OrderSide.OFFER,
+      });
+    }
+
+    return order as unknown as OrderV2;
   }
 
   /**
@@ -491,6 +497,7 @@ export class OpenSeaSDK {
     englishAuction,
     excludeOptionalCreatorFees = false,
     zone = ZeroAddress,
+    submitOrder = true,
   }: {
     asset: AssetWithTokenId;
     accountAddress: string;
@@ -506,6 +513,7 @@ export class OpenSeaSDK {
     englishAuction?: boolean;
     excludeOptionalCreatorFees?: boolean;
     zone?: string;
+    submitOrder?: boolean;
   }): Promise<OrderV2> {
     await this._requireAccountIsAvailable(accountAddress);
 
@@ -571,11 +579,15 @@ export class OpenSeaSDK {
     );
     const order = await executeAllActions();
 
-    return this.api.postOrder(order, {
-      protocol: "seaport",
-      protocolAddress: DEFAULT_SEAPORT_CONTRACT_ADDRESS,
-      side: OrderSide.LISTING,
-    });
+    if (submitOrder) {
+      return this.api.postOrder(order, {
+        protocol: "seaport",
+        protocolAddress: DEFAULT_SEAPORT_CONTRACT_ADDRESS,
+        side: OrderSide.LISTING,
+      });
+    }
+
+    return order as unknown as OrderV2;
   }
 
   /**

--- a/test/integration/getNFTs.spec.ts
+++ b/test/integration/getNFTs.spec.ts
@@ -5,7 +5,7 @@ import { Chain } from "../../src/types";
 
 suite("SDK: NFTs", () => {
   test("Get NFTs By Collection", async () => {
-    const response = await sdk.api.getNFTsByCollection("proof-moonbirds");
+    const response = await sdk.api.getNFTsByCollection("moonbirds");
     assert(response, "Response should exist.");
     assert.equal(response.nfts.length, 50, "Response should include 50 NFTs");
     assert(response.next, "Response should have a next cursor");

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -71,9 +71,9 @@ export const getRandomExpiration = (): number => {
   return now + randomSeconds;
 };
 
-export const getRandomSalt = (): string => {
+export const getRandomSalt = (): bigint => {
   // Generate a random 32-byte salt using crypto.randomBytes
   const saltBuffer = randomBytes(32);
-  // Convert to hexadecimal string with 0x prefix for BigInt compatibility
-  return "0x" + saltBuffer.toString("hex");
+  // Convert to BigInt using hex string representation
+  return BigInt("0x" + saltBuffer.toString("hex"));
 };

--- a/test/integration/setup.ts
+++ b/test/integration/setup.ts
@@ -70,3 +70,10 @@ export const getRandomExpiration = (): number => {
   const randomSeconds = (randomValue % range) + fifteenMinutes;
   return now + randomSeconds;
 };
+
+export const getRandomSalt = (): string => {
+  // Generate a random 32-byte salt using crypto.randomBytes
+  const saltBuffer = randomBytes(32);
+  // Convert to hexadecimal string with 0x prefix for BigInt compatibility
+  return "0x" + saltBuffer.toString("hex");
+};

--- a/test/integration/validateOrderOnchain.spec.ts
+++ b/test/integration/validateOrderOnchain.spec.ts
@@ -1,4 +1,3 @@
-import { OrderComponents } from "@opensea/seaport-js/lib/types";
 import { expect } from "chai";
 import { suite, test } from "mocha";
 import {
@@ -14,7 +13,7 @@ import { OFFER_AMOUNT } from "../utils/constants";
 
 // Polygon network integration test for onchain order validation
 suite("SDK: validateOrderOnchain - Polygon Network", () => {
-  test("Build listing order components and validate onchain", async function () {
+  test("Create listing and validate onchain", async function () {
     // Set timeout to 60 seconds for this complex test
     this.timeout(60_000);
 
@@ -26,45 +25,30 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
       this.skip();
     }
 
-    // Build listing order components directly without submitting to API
+    // Create and validate listing onchain in one call
     const asset = {
       tokenAddress: TOKEN_ADDRESS_POLYGON as string,
       tokenId: TOKEN_ID_POLYGON as string,
     };
 
-    const listingParams = {
+    const txHash = await sdkPolygon.createListingAndValidateOnchain({
       accountAddress: walletAddress,
       startAmount: LISTING_AMOUNT,
       asset,
       expirationTime: getRandomExpiration(),
       salt: getRandomSalt(),
-    };
-
-    // Build the order components directly using private helper method
-    const orderComponents = await (
-      sdkPolygon as unknown as {
-        _buildListingOrderComponents: (
-          params: typeof listingParams,
-        ) => Promise<OrderComponents>;
-      }
-    )._buildListingOrderComponents(listingParams);
-
-    console.log("Built listing order components for validation");
-
-    // Validate the order onchain directly
-    const txHash = await sdkPolygon.validateOrderOnchain(
-      orderComponents,
-      walletAddress,
-    );
+    });
 
     expect(txHash).to.be.a("string");
     expect(txHash).to.match(/^0x[0-9a-fA-F]{64}$/);
-    console.log(`Listing validated onchain with tx hash: ${txHash}`);
+    console.log(
+      `Listing created and validated onchain with tx hash: ${txHash}`,
+    );
 
-    console.log("✓ Listing order components successfully validated onchain");
+    console.log("✓ Listing successfully created and validated onchain");
   });
 
-  test("Build offer order components and validate onchain", async function () {
+  test("Create offer and validate onchain", async function () {
     // Set timeout to 60 seconds for this complex test
     this.timeout(60_000);
 
@@ -76,41 +60,24 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
       this.skip();
     }
 
-    // Build offer order components directly without submitting to API
+    // Create and validate offer onchain in one call
     const asset = {
       tokenAddress: TOKEN_ADDRESS_POLYGON as string,
       tokenId: TOKEN_ID_POLYGON as string,
     };
 
-    const offerParams = {
+    const txHash = await sdkPolygon.createOfferAndValidateOnchain({
       accountAddress: walletAddress,
       startAmount: +OFFER_AMOUNT, // Use the same constant as other tests
       asset,
       expirationTime: getRandomExpiration(),
       salt: getRandomSalt(),
-    };
-
-    // Build the offer components directly using private helper method
-    const orderComponents = await (
-      sdkPolygon as unknown as {
-        _buildOfferOrderComponents: (
-          params: typeof offerParams,
-        ) => Promise<OrderComponents>;
-      }
-    )._buildOfferOrderComponents(offerParams);
-
-    console.log("Built offer order components for validation");
-
-    // Validate the offer onchain directly
-    const txHash = await sdkPolygon.validateOrderOnchain(
-      orderComponents,
-      walletAddress,
-    );
+    });
 
     expect(txHash).to.be.a("string");
     expect(txHash).to.match(/^0x[0-9a-fA-F]{64}$/);
-    console.log(`Offer validated onchain with tx hash: ${txHash}`);
+    console.log(`Offer created and validated onchain with tx hash: ${txHash}`);
 
-    console.log("✓ Offer order components successfully validated onchain");
+    console.log("✓ Offer successfully created and validated onchain");
   });
 });

--- a/test/integration/validateOrderOnchain.spec.ts
+++ b/test/integration/validateOrderOnchain.spec.ts
@@ -36,6 +36,7 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
       startAmount: LISTING_AMOUNT,
       asset,
       expirationTime: getRandomExpiration(),
+      submitOrder: false,
     };
 
     // Create the listing first

--- a/test/integration/validateOrderOnchain.spec.ts
+++ b/test/integration/validateOrderOnchain.spec.ts
@@ -43,7 +43,7 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
     expectValidOrder(order);
     console.log(`Created order with hash: ${order.orderHash}`);
 
-    // Now validate the order onchain
+    // Validate the order onchain directly
     const txHash = await sdkPolygon.validateOrderOnchain(order, walletAddress);
     expect(txHash).to.be.a("string");
     expect(txHash).to.match(/^0x[0-9a-fA-F]{64}$/);
@@ -90,12 +90,9 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
     }
 
     if (!apiOrder) {
-      console.warn(
-        "Order not found in API after waiting - this might be expected in test environment",
+      throw new Error(
+        "Order not found in API after 10 seconds - onchain validation may have failed",
       );
-      // Don't fail the test if API doesn't return the order immediately
-      // as this could be due to indexing delays or test environment limitations
-      return;
     }
 
     // Verify the order exists in the API

--- a/test/integration/validateOrderOnchain.spec.ts
+++ b/test/integration/validateOrderOnchain.spec.ts
@@ -6,6 +6,7 @@ import {
   TOKEN_ID_POLYGON,
   walletAddress,
   getRandomExpiration,
+  getRandomSalt,
   sdkPolygon,
 } from "./setup";
 import { OrderSide } from "../../src/types";
@@ -32,11 +33,13 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
     };
 
     const expirationTime = getRandomExpiration();
+    const salt = getRandomSalt();
     const order = await sdkPolygon.createListing({
       accountAddress: walletAddress,
       startAmount: LISTING_AMOUNT,
       asset,
       expirationTime,
+      salt,
     });
 
     expect(order.orderHash).to.be.a("string");
@@ -126,11 +129,13 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
     };
 
     const expirationTime = getRandomExpiration();
+    const salt = getRandomSalt();
     const order = await sdkPolygon.createOffer({
       accountAddress: walletAddress,
       startAmount: +OFFER_AMOUNT, // Use the same constant as other tests
       asset,
       expirationTime,
+      salt,
     });
 
     expect(order.orderHash).to.be.a("string");

--- a/test/integration/validateOrderOnchain.spec.ts
+++ b/test/integration/validateOrderOnchain.spec.ts
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+import { suite, test } from "mocha";
+import {
+  LISTING_AMOUNT,
+  TOKEN_ADDRESS_POLYGON,
+  TOKEN_ID_POLYGON,
+  walletAddress,
+  getRandomExpiration,
+  sdkPolygon,
+} from "./setup";
+import { OrderSide } from "../../src/types";
+import { expectValidOrder } from "../utils/utils";
+
+// Polygon network integration test for onchain order validation
+suite("SDK: validateOrderOnchain - Polygon Network", () => {
+  test("Create listing and validate onchain, then verify in API", async function () {
+    // Set timeout to 60 seconds for this complex test
+    this.timeout(60_000);
+
+    // Skip if Polygon-specific environment variables are not set
+    if (!TOKEN_ADDRESS_POLYGON || !TOKEN_ID_POLYGON) {
+      console.log(
+        "Skipping test - missing Polygon token address or token ID environment variables",
+      );
+      this.skip();
+    }
+
+    // First, create a listing using existing Polygon test data
+    const asset = {
+      tokenAddress: TOKEN_ADDRESS_POLYGON as string,
+      tokenId: TOKEN_ID_POLYGON as string,
+    };
+
+    const listingParams = {
+      accountAddress: walletAddress,
+      startAmount: LISTING_AMOUNT,
+      asset,
+      expirationTime: getRandomExpiration(),
+    };
+
+    // Create the listing first
+    const order = await sdkPolygon.createListing(listingParams);
+    expectValidOrder(order);
+    console.log(`Created order with hash: ${order.orderHash}`);
+
+    // Now validate the order onchain
+    const txHash = await sdkPolygon.validateOrderOnchain(order, walletAddress);
+    expect(txHash).to.be.a("string");
+    expect(txHash).to.match(/^0x[0-9a-fA-F]{64}$/);
+    console.log(`Order validated onchain with tx hash: ${txHash}`);
+
+    // Wait a bit for the transaction to be processed
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Query the API to verify the order exists and is validated onchain
+    let apiOrder;
+    let attempts = 0;
+    const maxAttempts = 10; // Max 10 attempts over ~10 seconds
+
+    while (attempts < maxAttempts) {
+      try {
+        const ordersResponse = await sdkPolygon.api.getOrders({
+          protocol: "seaport",
+          side: OrderSide.LISTING,
+          maker: walletAddress,
+        });
+
+        if (ordersResponse.orders.length > 0) {
+          // Look for our specific order by comparing order hash
+          apiOrder = ordersResponse.orders.find(
+            (o) => o.orderHash === order.orderHash,
+          );
+          if (apiOrder) {
+            break;
+          }
+        }
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.log(`Attempt ${attempts + 1} failed:`, errorMessage);
+      }
+
+      attempts++;
+      if (attempts < maxAttempts) {
+        console.log(
+          `Order not found in API yet, waiting... (attempt ${attempts}/${maxAttempts})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    if (!apiOrder) {
+      console.warn(
+        "Order not found in API after waiting - this might be expected in test environment",
+      );
+      // Don't fail the test if API doesn't return the order immediately
+      // as this could be due to indexing delays or test environment limitations
+      return;
+    }
+
+    // Verify the order exists in the API
+    expect(apiOrder).to.exist;
+    expect(apiOrder.orderHash).to.equal(order.orderHash);
+    expect(apiOrder.protocolAddress).to.equal(order.protocolAddress);
+
+    console.log("✓ Order successfully validated onchain and found in API");
+  });
+});

--- a/test/integration/validateOrderOnchain.spec.ts
+++ b/test/integration/validateOrderOnchain.spec.ts
@@ -8,10 +8,12 @@ import {
   getRandomExpiration,
   sdkPolygon,
 } from "./setup";
+import { OrderSide } from "../../src/types";
+import { OFFER_AMOUNT } from "../utils/constants";
 
 // Polygon network integration test for onchain order validation
 suite("SDK: validateOrderOnchain - Polygon Network", () => {
-  test("Create listing and validate onchain", async function () {
+  test("Create listing and validate onchain, then verify in API", async function () {
     // Set timeout to 60 seconds for this complex test
     this.timeout(60_000);
 
@@ -23,29 +25,89 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
       this.skip();
     }
 
-    // Create and validate listing onchain in one call
+    // First create the listing to get the order hash
     const asset = {
       tokenAddress: TOKEN_ADDRESS_POLYGON as string,
       tokenId: TOKEN_ID_POLYGON as string,
     };
 
-    const txHash = await sdkPolygon.createListingAndValidateOnchain({
+    const expirationTime = getRandomExpiration();
+    const order = await sdkPolygon.createListing({
       accountAddress: walletAddress,
       startAmount: LISTING_AMOUNT,
       asset,
-      expirationTime: getRandomExpiration(),
+      expirationTime,
     });
+
+    expect(order.orderHash).to.be.a("string");
+    console.log(`Created listing with order hash: ${order.orderHash}`);
+
+    // Now validate the order onchain using the order components
+    const orderComponents = order.protocolData.parameters;
+    const txHash = await sdkPolygon.validateOrderOnchain(
+      orderComponents,
+      walletAddress,
+    );
 
     expect(txHash).to.be.a("string");
     expect(txHash).to.match(/^0x[0-9a-fA-F]{64}$/);
-    console.log(
-      `Listing created and validated onchain with tx hash: ${txHash}`,
-    );
+    console.log(`Order validated onchain with tx hash: ${txHash}`);
 
-    console.log("✓ Listing successfully created and validated onchain");
+    // Wait for the transaction to be processed
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Query the API to verify the order exists and can be found by order hash
+    let apiOrder;
+    let attempts = 0;
+    const maxAttempts = 10; // Max 10 attempts over ~10 seconds
+
+    while (attempts < maxAttempts) {
+      try {
+        const ordersResponse = await sdkPolygon.api.getOrders({
+          protocol: "seaport",
+          side: OrderSide.LISTING,
+          maker: walletAddress,
+        });
+
+        if (ordersResponse.orders.length > 0) {
+          // Look for our specific order by comparing order hash
+          apiOrder = ordersResponse.orders.find(
+            (o) => o.orderHash === order.orderHash,
+          );
+          if (apiOrder) {
+            break;
+          }
+        }
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.log(`Attempt ${attempts + 1} failed:`, errorMessage);
+      }
+
+      attempts++;
+      if (attempts < maxAttempts) {
+        console.log(
+          `Order not found in API yet, waiting... (attempt ${attempts}/${maxAttempts})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    if (!apiOrder) {
+      throw new Error(
+        `Order with hash ${order.orderHash} not found in API after 10 seconds - onchain validation may have failed`,
+      );
+    }
+
+    // Verify the order exists in the API
+    expect(apiOrder).to.exist;
+    expect(apiOrder.orderHash).to.equal(order.orderHash);
+    expect(apiOrder.protocolAddress).to.equal(order.protocolAddress);
+
+    console.log("✓ Listing successfully validated onchain and found in API");
   });
 
-  test("Create offer and validate onchain", async function () {
+  test("Create offer and validate onchain, then verify in API", async function () {
     // Set timeout to 60 seconds for this complex test
     this.timeout(60_000);
 
@@ -57,23 +119,85 @@ suite("SDK: validateOrderOnchain - Polygon Network", () => {
       this.skip();
     }
 
-    // Create and validate offer onchain in one call
+    // First create the offer to get the order hash
     const asset = {
       tokenAddress: TOKEN_ADDRESS_POLYGON as string,
       tokenId: TOKEN_ID_POLYGON as string,
     };
 
-    const txHash = await sdkPolygon.createOfferAndValidateOnchain({
+    const expirationTime = getRandomExpiration();
+    const order = await sdkPolygon.createOffer({
       accountAddress: walletAddress,
-      startAmount: "0.001", // Small offer amount in ETH
+      startAmount: +OFFER_AMOUNT, // Use the same constant as other tests
       asset,
-      expirationTime: getRandomExpiration(),
+      expirationTime,
     });
+
+    expect(order.orderHash).to.be.a("string");
+    console.log(`Created offer with order hash: ${order.orderHash}`);
+
+    // Now validate the order onchain using the order components
+    const orderComponents = order.protocolData.parameters;
+    const txHash = await sdkPolygon.validateOrderOnchain(
+      orderComponents,
+      walletAddress,
+    );
 
     expect(txHash).to.be.a("string");
     expect(txHash).to.match(/^0x[0-9a-fA-F]{64}$/);
-    console.log(`Offer created and validated onchain with tx hash: ${txHash}`);
+    console.log(`Order validated onchain with tx hash: ${txHash}`);
 
-    console.log("✓ Offer successfully created and validated onchain");
+    // Wait for the transaction to be processed
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+
+    // Query the API to verify the order exists and can be found by order hash
+    let apiOrder;
+    let attempts = 0;
+    const maxAttempts = 10; // Max 10 attempts over ~10 seconds
+
+    while (attempts < maxAttempts) {
+      try {
+        const ordersResponse = await sdkPolygon.api.getOrders({
+          protocol: "seaport",
+          side: OrderSide.OFFER,
+          maker: walletAddress,
+        });
+
+        if (ordersResponse.orders.length > 0) {
+          // Look for our specific order by comparing order hash
+          apiOrder = ordersResponse.orders.find(
+            (o) => o.orderHash === order.orderHash,
+          );
+          if (apiOrder) {
+            break;
+          }
+        }
+      } catch (error: unknown) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.log(`Attempt ${attempts + 1} failed:`, errorMessage);
+      }
+
+      attempts++;
+      if (attempts < maxAttempts) {
+        console.log(
+          `Order not found in API yet, waiting... (attempt ${attempts}/${maxAttempts})`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+    }
+
+    if (!apiOrder) {
+      throw new Error(
+        `Order with hash ${order.orderHash} not found in API after 10 seconds - onchain validation may have failed`,
+      );
+    }
+
+    // Verify the order exists in the API
+    expect(apiOrder).to.exist;
+    expect(apiOrder.orderHash).to.equal(order.orderHash);
+    expect(apiOrder.protocolAddress).to.equal(order.protocolAddress);
+
+    console.log("✓ Offer successfully validated onchain and found in API");
   });
 });


### PR DESCRIPTION
This adds a new method to validate orders onchain using Seaport's validate() method, which makes orders cheaper to fulfill since signature verification is skipped during fulfillment.

- Add validateOrderOnchain method to OpenSeaSDK
- Include comprehensive JSDoc documentation explaining benefits
- Add integration test for Polygon network using existing test infrastructure
- Bump package version to 7.2.1

The method submits orders onchain and pre-validates them using Seaport. While not strictly required (orders can be submitted to the API for free), this approach reduces gas costs during fulfillment at the expense of upfront validation gas costs.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
