### PR TITLE
Minor internal api cleanups to improve comments and avoid errors

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -120,8 +120,6 @@ export class OpenSeaAPI {
    * @param options.side The side of the order (listing or offer)
    * @param options.protocol The protocol, typically seaport, to query orders for
    * @param options.orderDirection The direction to sort the orders
-   * @param options.orderBy The field to sort the orders by
-   * @param options.limit The number of orders to retrieve
    * @param options.maker Filter by the wallet address of the order maker
    * @param options.taker Filter by  wallet address of the order taker
    * @param options.asset_contract_address Address of the NFT's contract
@@ -136,14 +134,13 @@ export class OpenSeaAPI {
     side,
     protocol = "seaport",
     orderDirection = "desc",
-    orderBy = "created_date",
     ...restOptions
-  }: Omit<OrdersQueryOptions, "limit">): Promise<OrderV2> {
+  }: Omit<OrdersQueryOptions, "limit" | "orderBy">): Promise<OrderV2> {
     const { orders } = await this.get<OrdersQueryResponse>(
       getOrdersAPIPath(this.chain, protocol, side),
       serializeOrdersQueryOptions({
         limit: 1,
-        orderBy,
+        orderBy: "created_date",
         orderDirection,
         ...restOptions,
       }),
@@ -161,7 +158,6 @@ export class OpenSeaAPI {
    * @param options.protocol The protocol, typically seaport, to query orders for
    * @param options.orderDirection The direction to sort the orders
    * @param options.orderBy The field to sort the orders by
-   * @param options.limit The number of orders to retrieve
    * @param options.maker Filter by the wallet address of the order maker
    * @param options.taker Filter by  wallet address of the order taker
    * @param options.asset_contract_address Address of the NFT's contract


### PR DESCRIPTION

<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation

For a personal project I needed to generate the calldata for (but not actually fulfill) a listed NFT. The SDK has an internal api.ts that supports this but from my brief searching it looks like it isn't exposed.



## Solution

<img width="775" height="108" alt="image" src="https://github.com/user-attachments/assets/81032c4a-5934-4137-89cf-f9186b6bc0fb" />

I ended up forking the repo and using it locally. In doing so, i found that the JSDoc for `api.getOrder` and `api.getOrders` had an `options.limit` that was in fact omitted in the typescript. Additionally, passing an `orderBy: "eth_price"` to `api.getOrder` throws an error, so I also removed that as a configurable option.

A couple of other things i noticed:
- a .env.example would be great, as well as updating the contributing.md to call out the need for a .env to run the tests. In addition, unless it's already done so, exposing the calldata generation functions from api.ts on the exported OpenSeaSDK object would be great!
