### PR TITLE
fix: handle empty encoded token ids (#1)

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -464,6 +464,10 @@ export const decodeTokenIds = (encodedTokenIds: string): string[] => {
     return ["*"];
   }
 
+  if (encodedTokenIds === "") {
+    return [];
+  }
+
   const validFormatRegex = /^(\d+(:\d+)?)(,\d+(:\d+)?)*$/;
 
   if (!validFormatRegex.test(encodedTokenIds)) {


### PR DESCRIPTION
**Motivation**

> `decodeTokenIds` promised to return an empty array for empty input but previously threw a formatting error instead.

**Linked Issue(s)**

> None.

**Solution**

> Short-circuit the decoder when the input is an empty string so it matches the documented behavior.

**Testing**

> Not run (library-only change).

**Notes for Reviewers**

> Single-line guard, no downstream impact.