### PR TITLE
Remove coverage output from CI test runs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -37,18 +37,10 @@ jobs:
         run: npm install
 
       - name: Run tests
-        run: npm run test
+        run: npm run test:ci
         env:
           OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-
-      - name: Create code coverage report
-        run: npm run coverage-report
-
-      - name: Upload code coverage
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   test-integration:
     runs-on: ubuntu-latest
@@ -63,7 +55,7 @@ jobs:
         run: npm install
 
       - name: Run integration tests
-        run: npm run test:integration
+        run: npm run test:integration:ci
         env:
           OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "prettier:fix": "prettier --write .",
     "test": "nyc mocha --config ./.mocharc-unit.json",
     "test:all": "concurrently \"npm run test\" \"npm run test:integration\"",
-    "test:integration": "nyc mocha --config ./.mocharc-integration.json"
+    "test:ci": "mocha --config ./.mocharc-unit.json",
+    "test:integration": "nyc mocha --config ./.mocharc-integration.json",
+    "test:integration:ci": "mocha --config ./.mocharc-integration.json"
   },
   "types": "lib/index.d.ts",
   "dependencies": {


### PR DESCRIPTION
- Add test:ci and test:integration:ci scripts without nyc coverage
- Update CI workflow to use new scripts for cleaner output
- Remove coverage reporting steps that were creating noise in test output

This provides cleaner CI test output without coverage tables.

Note: GitHub Actions will still mask values that match secrets for security. This is expected behavior and cannot be fully disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)