### PR TITLE
feat: add bulk order cancellation and bulk transfer methods

### DIFF
--- a/src/abi/TransferHelper.json
+++ b/src/abi/TransferHelper.json
@@ -1,0 +1,53 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "enum ConduitItemType",
+            "name": "itemType",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "identifier",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct TransferHelperItem[]",
+        "name": "items",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "conduitKey",
+        "type": "bytes32"
+      }
+    ],
+    "name": "bulkTransfer",
+    "outputs": [
+      {
+        "internalType": "bytes4",
+        "name": "magicValue",
+        "type": "bytes4"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -28,6 +28,8 @@ import {
   WPOL_ADDRESS,
   GUNZILLA_SEAPORT_1_6_ADDRESS,
 } from "./constants";
+
+const TRANSFER_HELPER_ADDRESS = "0x0000000000c2d145a2526bd8c716263bfebe1a72";
 import {
   constructPrivateListingCounterOrder,
   getPrivateListingConsiderations,
@@ -1208,6 +1210,78 @@ export class OpenSeaSDK {
   }
 
   /**
+   * Offchain cancel multiple orders by their order hashes when protected by the SignedZone.
+   * This is a gas-free alternative to onchain cancellation for orders using the SignedZone.
+   * Protocol and Chain are required to prevent hash collisions.
+   * Please note cancellation is only assured if a fulfillment signature was not vended prior to cancellation.
+   * @param options
+   * @param options.protocolAddress The Seaport address for the orders. All orders must use the same protocol.
+   * @param options.orderHashes Array of order hashes to cancel.
+   * @param options.chain The chain where the orders are located. Defaults to the SDK's configured chain.
+   * @param options.offererSignatures Optional array of EIP-712 signatures from the offerer, one for each order hash.
+   *                                  If not provided, the user associated with the API Key will be checked instead.
+   * @param options.useSignerToDeriveOffererSignatures If true, derive the offererSignatures from the Ethers signer passed into this sdk.
+   * @returns Array of responses from the API, one for each order.
+   *
+   * @throws Error if orderHashes and offererSignatures arrays have different lengths.
+   */
+  public async offchainCancelOrders({
+    protocolAddress = DEFAULT_SEAPORT_CONTRACT_ADDRESS,
+    orderHashes,
+    chain = this.chain,
+    offererSignatures,
+    useSignerToDeriveOffererSignatures = false,
+  }: {
+    protocolAddress?: string;
+    orderHashes: string[];
+    chain?: Chain;
+    offererSignatures?: string[];
+    useSignerToDeriveOffererSignatures?: boolean;
+  }) {
+    requireValidProtocol(protocolAddress);
+
+    if (orderHashes.length === 0) {
+      throw new Error("At least one order hash must be provided");
+    }
+
+    if (offererSignatures && offererSignatures.length !== orderHashes.length) {
+      throw new Error(
+        "offererSignatures array must have the same length as orderHashes array",
+      );
+    }
+
+    const results = [];
+    for (let i = 0; i < orderHashes.length; i++) {
+      const orderHash = orderHashes[i];
+      let offererSignature = offererSignatures?.[i];
+
+      if (useSignerToDeriveOffererSignatures) {
+        offererSignature = await this._getOffererSignature(
+          protocolAddress,
+          orderHash,
+          chain,
+        );
+      }
+
+      try {
+        const result = await this.api.offchainCancelOrder(
+          protocolAddress,
+          orderHash,
+          chain,
+          offererSignature,
+        );
+        results.push(result);
+      } catch (error) {
+        throw new Error(
+          `Failed to cancel order with hash ${orderHash}: ${error}`,
+        );
+      }
+    }
+
+    return results;
+  }
+
+  /**
    * Returns whether an order is fulfillable.
    * An order may not be fulfillable if a target item's transfer function
    * is locked for some reason, e.g. an item is being rented within a game
@@ -1396,6 +1470,137 @@ export class OpenSeaSDK {
         error,
         accountAddress: fromAddress,
       });
+    }
+  }
+
+  /**
+   * Bulk transfer multiple assets using OpenSea's TransferHelper contract.
+   * This method is more gas-efficient than calling transfer() multiple times.
+   * Note: All assets must be approved for transfer to the OpenSea conduit before calling this method.
+   * @param options
+   * @param options.assets Array of assets to transfer. Each asset must have tokenStandard set.
+   * @param options.fromAddress The address to transfer from
+   * @param options.overrides Transaction overrides, ignored if not set.
+   * @returns Transaction hash of the bulk transfer
+   *
+   * @throws Error if any asset is missing required fields (tokenId for NFTs, amount for ERC20/ERC1155).
+   * @throws Error if the fromAddress is not available through wallet or provider.
+   */
+  public async bulkTransfer({
+    assets,
+    fromAddress,
+    overrides,
+  }: {
+    assets: Array<{
+      asset: AssetWithTokenStandard;
+      toAddress: string;
+      amount?: BigNumberish;
+    }>;
+    fromAddress: string;
+    overrides?: Overrides;
+  }): Promise<string> {
+    await this._requireAccountIsAvailable(fromAddress);
+
+    if (assets.length === 0) {
+      throw new Error("At least one asset must be provided");
+    }
+
+    // Build transfer items array for TransferHelper
+    const transferItems: Array<{
+      itemType: number;
+      token: string;
+      identifier: string;
+      amount: string;
+      recipient: string;
+    }> = [];
+
+    for (const { asset, toAddress, amount } of assets) {
+      let itemType: number;
+      let identifier: string;
+      let transferAmount: string;
+
+      switch (asset.tokenStandard) {
+        case TokenStandard.ERC20:
+          itemType = 1; // ERC20
+          identifier = "0";
+          if (!amount) {
+            throw new Error("Missing ERC20 amount for bulk transfer");
+          }
+          transferAmount = amount.toString();
+          break;
+
+        case TokenStandard.ERC721:
+          itemType = 2; // ERC721
+          if (asset.tokenId === undefined || asset.tokenId === null) {
+            throw new Error("Missing ERC721 tokenId for bulk transfer");
+          }
+          identifier = asset.tokenId.toString();
+          transferAmount = "1";
+          break;
+
+        case TokenStandard.ERC1155:
+          itemType = 3; // ERC1155
+          if (asset.tokenId === undefined || asset.tokenId === null) {
+            throw new Error("Missing ERC1155 tokenId for bulk transfer");
+          }
+          if (!amount) {
+            throw new Error("Missing ERC1155 amount for bulk transfer");
+          }
+          identifier = asset.tokenId.toString();
+          transferAmount = amount.toString();
+          break;
+
+        default:
+          throw new Error(
+            `Unsupported token standard for bulk transfer: ${asset.tokenStandard}`,
+          );
+      }
+
+      transferItems.push({
+        itemType,
+        token: asset.tokenAddress,
+        identifier,
+        amount: transferAmount,
+        recipient: toAddress,
+      });
+    }
+
+    // Create TransferHelper contract instance
+    const transferHelper = new Contract(
+      TRANSFER_HELPER_ADDRESS,
+      [
+        "function bulkTransfer(tuple(uint8 itemType, address token, uint256 identifier, uint256 amount, address recipient)[] items, bytes32 conduitKey) external returns (bytes4)",
+      ],
+      this._signerOrProvider,
+    );
+
+    this._dispatch(EventType.Transfer, {
+      accountAddress: fromAddress,
+      assets,
+    });
+
+    try {
+      // Use OpenSea conduit key for bulk transfers
+      const transaction = await transferHelper.bulkTransfer(
+        transferItems,
+        OPENSEA_CONDUIT_KEY_2,
+        { ...overrides, from: fromAddress },
+      );
+
+      await this._confirmTransaction(
+        transaction.hash,
+        EventType.Transfer,
+        `Bulk transferring ${assets.length} asset(s)`,
+      );
+
+      return transaction.hash;
+    } catch (error) {
+      console.error(error);
+      this._dispatch(EventType.TransactionDenied, {
+        error,
+        accountAddress: fromAddress,
+      });
+      throw error;
     }
   }
 

--- a/test/integration/cancelOrders.spec.ts
+++ b/test/integration/cancelOrders.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+import { describe, test } from "mocha";
+import { Chain } from "../../src/types";
+import {
+  getSdkForChain,
+  walletAddress,
+  requireIntegrationEnv,
+} from "../utils/setupIntegration";
+
+describe("SDK: Cancel Orders Integration Tests", () => {
+  beforeEach(() => {
+    requireIntegrationEnv();
+  });
+
+  describe("offchainCancelOrders", () => {
+    test("Should successfully cancel a single order offchain with useSignerToDeriveOffererSignatures", async function () {
+      // This test would require a real order to cancel
+      // For now, we'll just verify the method exists and can be called with proper parameters
+      this.skip();
+    });
+
+    test("Should successfully cancel multiple orders offchain", async function () {
+      // This test would require real orders to cancel
+      // For now, we'll just verify the method exists
+      this.skip();
+    });
+
+    test("Should handle API errors gracefully when canceling invalid order hash", async function () {
+      this.timeout(30000);
+
+      try {
+        // Use a fake order hash that doesn't exist
+        const fakeOrderHash =
+          "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+        // Use a testnet (Base Sepolia) to keep costs low
+        await getSdkForChain(Chain.BaseSepolia).offchainCancelOrders({
+          orderHashes: [fakeOrderHash],
+        });
+
+        throw new Error("Should have thrown an error");
+      } catch (error: any) {
+        // Expect the error to be from the API (order not found or unauthorized)
+        expect(error.message).to.satisfy((msg: string) =>
+          msg.includes("Failed to cancel order") || msg.includes("API"),
+        );
+      }
+    });
+  });
+});

--- a/test/sdk/misc.spec.ts
+++ b/test/sdk/misc.spec.ts
@@ -201,4 +201,158 @@ suite("SDK: misc", () => {
       ]);
     });
   });
+
+  describe("offchainCancelOrders", () => {
+    test("Should throw an error when no order hashes are provided", async () => {
+      try {
+        await sdk.offchainCancelOrders({
+          orderHashes: [],
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include("At least one order hash must be provided");
+      }
+    });
+
+    test("Should throw an error when offererSignatures length doesn't match orderHashes length", async () => {
+      try {
+        await sdk.offchainCancelOrders({
+          orderHashes: ["0x123", "0x456"],
+          offererSignatures: ["0xabc"],
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include(
+          "offererSignatures array must have the same length as orderHashes array",
+        );
+      }
+    });
+  });
+
+  describe("bulkTransfer", () => {
+    const wallet = ethers.Wallet.createRandom();
+    const accountAddress = wallet.address;
+    const recipientAddress = ethers.Wallet.createRandom().address;
+
+    test("Should throw an error when using bulkTransfer without wallet", async () => {
+      const expectedErrorMessage = `Specified accountAddress is not available through wallet or provider: ${accountAddress}`;
+
+      try {
+        await sdk.bulkTransfer({
+          assets: [
+            {
+              asset: {
+                tokenAddress: BAYC_CONTRACT_ADDRESS,
+                tokenId: "1",
+                tokenStandard: "erc721",
+              },
+              toAddress: recipientAddress,
+            },
+          ],
+          fromAddress: accountAddress,
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include(expectedErrorMessage);
+      }
+    });
+
+    test("Should throw an error when assets array is empty", async () => {
+      try {
+        await sdk.bulkTransfer({
+          assets: [],
+          fromAddress: accountAddress,
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include("At least one asset must be provided");
+      }
+    });
+
+    test("Should throw an error when ERC20 amount is missing", async () => {
+      try {
+        await sdk.bulkTransfer({
+          assets: [
+            {
+              asset: {
+                tokenAddress: "0x0f5d2fb29fb7d3cfee444a200298f468908cc942", // MANA
+                tokenStandard: "erc20",
+              },
+              toAddress: recipientAddress,
+            },
+          ],
+          fromAddress: accountAddress,
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include("Missing ERC20 amount for bulk transfer");
+      }
+    });
+
+    test("Should throw an error when ERC721 tokenId is missing", async () => {
+      try {
+        await sdk.bulkTransfer({
+          assets: [
+            {
+              asset: {
+                tokenAddress: BAYC_CONTRACT_ADDRESS,
+                tokenStandard: "erc721",
+              },
+              toAddress: recipientAddress,
+            },
+          ],
+          fromAddress: accountAddress,
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include("Missing ERC721 tokenId for bulk transfer");
+      }
+    });
+
+    test("Should throw an error when ERC1155 tokenId is missing", async () => {
+      try {
+        await sdk.bulkTransfer({
+          assets: [
+            {
+              asset: {
+                tokenAddress: "0x495f947276749ce646f68ac8c248420045cb7b5e",
+                tokenStandard: "erc1155",
+              },
+              toAddress: recipientAddress,
+              amount: "1",
+            },
+          ],
+          fromAddress: accountAddress,
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include(
+          "Missing ERC1155 tokenId for bulk transfer",
+        );
+      }
+    });
+
+    test("Should throw an error when ERC1155 amount is missing", async () => {
+      try {
+        await sdk.bulkTransfer({
+          assets: [
+            {
+              asset: {
+                tokenAddress: "0x495f947276749ce646f68ac8c248420045cb7b5e",
+                tokenId: "1",
+                tokenStandard: "erc1155",
+              },
+              toAddress: recipientAddress,
+            },
+          ],
+          fromAddress: accountAddress,
+        });
+        throw new Error("should have thrown");
+      } catch (e: any) {
+        expect(e.message).to.include(
+          "Missing ERC1155 amount for bulk transfer",
+        );
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

This PR adds two new non-breaking methods to the OpenSeaSDK to address feature requests from #1312:

1. **`offchainCancelOrders()`** - Gas-free bulk cancellation for orders protected by SignedZone
2. **`bulkTransfer()`** - Efficient bulk asset transfer using OpenSea's TransferHelper contract

## Changes

### offchainCancelOrders()

- Enables gas-free bulk cancellation of multiple orders that use the SignedZone
- Accepts an array of order hashes instead of requiring full OrderV2 objects
- Supports both API-key-based cancellation and signature-based cancellation
- Can derive EIP-712 signatures automatically when `useSignerToDeriveOffererSignatures` is enabled
- Returns array of API responses for all cancelled orders

**Usage example:**
```typescript
await sdk.offchainCancelOrders({
  orderHashes: ['0x...', '0x...'],
  useSignerToDeriveOffererSignatures: true,
});
```

### bulkTransfer()

- Enables gas-efficient bulk transfer of multiple assets (ERC20, ERC721, ERC1155) in a single transaction
- Uses OpenSea's TransferHelper contract (0x0000000000c2d145a2526bd8c716263bfebe1a72)
- Supports transfers to different recipients for each asset
- Requires prior approval to OpenSea's conduit (0x963f00d3ff000064ffcba824b800c0000000c300)

**Usage example:**
```typescript
const txHash = await sdk.bulkTransfer({
  assets: [
    {
      asset: {
        tokenAddress: '0x...',
        tokenId: '1',
        tokenStandard: 'erc721'
      },
      toAddress: '0x...'
    },
    // ... more assets
  ],
  fromAddress: walletAddress,
});
```

### Other Changes

- Added TransferHelper ABI file (`src/abi/TransferHelper.json`)
- Added comprehensive unit tests for both methods
- Added integration test scaffolding for order cancellation

## Test Plan

- [x] Unit tests for `offchainCancelOrders()` error handling
- [x] Unit tests for `bulkTransfer()` validation and error cases
- [x] Integration test structure for cancel orders (skipped, requires real orders)
- [x] All existing tests pass

## Notes

- Both methods are fully backward compatible
- `offchainCancelOrders()` only works for orders protected by SignedZone
- `bulkTransfer()` requires assets to be pre-approved to the OpenSea conduit
- Integration tests use testnet (Base Sepolia) to minimize costs

Addresses #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)