### PR TITLE
feat: add offchainCancelOrders for gas-free bulk order cancellation

### DIFF
--- a/test/integration/offchainCancelOrders.spec.ts
+++ b/test/integration/offchainCancelOrders.spec.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+import { describe, test } from "mocha";
+import { Chain } from "../../src/types";
+import {
+  getSdkForChain,
+  requireIntegrationEnv,
+} from "../utils/setupIntegration";
+
+describe("SDK: offchainCancelOrders Integration Tests", () => {
+  beforeEach(() => {
+    requireIntegrationEnv();
+  });
+
+  test("Should successfully cancel a single order offchain with useSignerToDeriveOffererSignatures", async function () {
+    // This test would require a real order to cancel
+    // For now, we'll just verify the method exists and can be called with proper parameters
+    this.skip();
+  });
+
+  test("Should successfully cancel multiple orders offchain", async function () {
+    // This test would require real orders to cancel
+    // For now, we'll just verify the method exists
+    this.skip();
+  });
+
+  test("Should handle API errors gracefully when canceling invalid order hash", async function () {
+    this.timeout(30000);
+
+    try {
+      // Use a fake order hash that doesn't exist
+      const fakeOrderHash =
+        "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+      // Use a testnet (Base Sepolia) to keep costs low
+      await getSdkForChain(Chain.BaseSepolia).offchainCancelOrders({
+        orderHashes: [fakeOrderHash],
+      });
+
+      throw new Error("Should have thrown an error");
+    } catch (error: any) {
+      // Expect the error to be from the API (order not found or unauthorized)
+      expect(error.message).to.satisfy((msg: string) =>
+        msg.includes("Failed to cancel order") || msg.includes("API"),
+      );
+    }
+  });
+});

--- a/test/sdk/cancelOrders.spec.ts
+++ b/test/sdk/cancelOrders.spec.ts
@@ -1,0 +1,31 @@
+import { assert, expect } from "chai";
+import { ethers } from "ethers";
+import { suite, test } from "mocha";
+import { sdk } from "../utils/sdk";
+
+suite("SDK: offchainCancelOrders", () => {
+  test("Should throw an error when no order hashes are provided", async () => {
+    try {
+      await sdk.offchainCancelOrders({
+        orderHashes: [],
+      });
+      throw new Error("should have thrown");
+    } catch (e: any) {
+      expect(e.message).to.include("At least one order hash must be provided");
+    }
+  });
+
+  test("Should throw an error when offererSignatures length doesn't match orderHashes length", async () => {
+    try {
+      await sdk.offchainCancelOrders({
+        orderHashes: ["0x123", "0x456"],
+        offererSignatures: ["0xabc"],
+      });
+      throw new Error("should have thrown");
+    } catch (e: any) {
+      expect(e.message).to.include(
+        "offererSignatures array must have the same length as orderHashes array",
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the `offchainCancelOrders()` method to the OpenSeaSDK, enabling gas-free bulk cancellation of orders protected by SignedZone.

## Changes

### offchainCancelOrders()

- Enables gas-free bulk cancellation of multiple orders that use the SignedZone
- Accepts an array of order hashes instead of requiring full OrderV2 objects
- Supports both API-key-based cancellation and signature-based cancellation
- Can derive EIP-712 signatures automatically when `useSignerToDeriveOffererSignatures` is enabled
- Returns array of API responses for all cancelled orders

**Usage example:**
```typescript
await sdk.offchainCancelOrders({
  orderHashes: ['0x...', '0x...'],
  useSignerToDeriveOffererSignatures: true,
});
```

### Tests

- Added unit tests for error handling in `test/sdk/cancelOrders.spec.ts`
- Added integration test scaffolding in `test/integration/offchainCancelOrders.spec.ts` (uses Base Sepolia testnet)

## Test Plan

- [x] Unit tests for `offchainCancelOrders()` error handling
- [x] Integration test structure for cancel orders (skipped, requires real orders)
- [x] All existing tests pass

## Notes

- This method is fully backward compatible
- `offchainCancelOrders()` only works for orders protected by SignedZone
- Cancellation is only assured if a fulfillment signature was not vended prior to cancellation
- Integration tests use testnet (Base Sepolia) to minimize costs

Addresses #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)