### PR TITLE
Skip test for getting collections for all chains

### DIFF
--- a/test/integration/getCollection.spec.ts
+++ b/test/integration/getCollection.spec.ts
@@ -68,7 +68,7 @@ suite("SDK: getCollection", () => {
     assert(stats.intervals, "Intervals should exist");
   });
 
-  test("Get Collections for all chains", async () => {
+  test.skip("Get Collections for all chains", async () => {
     // Excluding Solana (no NFT collections)
     const chains = Object.values(Chain).filter(
       (chain) => chain !== Chain.Solana,


### PR DESCRIPTION
API currently having some issues with some of the longer tail chains, skipping test until fix then will re-enable