### PR TITLE
fix: pass correct Seaport contract address during initialization

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -25,7 +25,11 @@ import {
   AssetWithTokenStandard,
   AssetWithTokenId,
 } from "./types";
-import { getDefaultConduit, getOfferPaymentToken } from "./utils/utils";
+import {
+  getDefaultConduit,
+  getOfferPaymentToken,
+  getSeaportAddress,
+} from "./utils/utils";
 
 /**
  * The OpenSea SDK main class.
@@ -78,11 +82,15 @@ export class OpenSeaSDK {
     this._signerOrProvider = signerOrProvider ?? this.provider;
 
     const defaultConduit = getDefaultConduit(this.chain);
+    const seaportAddress = getSeaportAddress(this.chain);
     this.seaport = new Seaport(this._signerOrProvider, {
       conduitKeyToConduit: {
         [defaultConduit.key]: defaultConduit.address,
       },
-      overrides: { defaultConduitKey: defaultConduit.key },
+      overrides: {
+        defaultConduitKey: defaultConduit.key,
+        contractAddress: seaportAddress,
+      },
     });
 
     // Emit events


### PR DESCRIPTION
## Problem
The SDK was creating Seaport instances without specifying the contract address, causing seaport-js to default to the cross-chain Seaport address. This resulted in "could not decode result data" errors on chains like Somnia that use custom Seaport deployments (Gunzilla Seaport at `0x00000000006687982678b03100B9bDC8be440814`).

### Error Example
```
Error: could not decode result data (value="0x", info={"method": "getCounter", "signature": "getCounter(address)"}, code=BAD_DATA)
```

This happened because the Seaport contract at the default address doesn't exist on Somnia.

## Solution
- Import `getSeaportAddress` utility function in SDK initialization
- Pass `contractAddress` in Seaport `overrides` config based on the chain
- Ensures chains like Somnia correctly use the Gunzilla Seaport address

## Changes
- Updated `src/sdk.ts` to:
  - Import `getSeaportAddress` from utils
  - Call `getSeaportAddress(this.chain)` during initialization
  - Pass the address in `overrides.contractAddress` to Seaport constructor

## Testing
- All 504 tests pass
- Verified `getSeaportAddress(Chain.Somnia)` returns Gunzilla Seaport address via existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)