### PR TITLE
fix: avoid serializing undefined token ids

### DIFF
--- a/src/orders/utils.ts
+++ b/src/orders/utils.ts
@@ -168,7 +168,9 @@ export const serializeOrdersQueryOptions = (
     owner: options.owner,
     listed_after: options.listedAfter,
     listed_before: options.listedBefore,
-    token_ids: options.tokenIds ?? [options.tokenId],
+    token_ids:
+      options.tokenIds ??
+      (options.tokenId !== undefined ? [options.tokenId] : undefined),
     asset_contract_address: options.assetContractAddress,
     order_by: options.orderBy,
     order_direction: options.orderDirection,

--- a/test/api/getOrders.spec.ts
+++ b/test/api/getOrders.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { suite, test } from "mocha";
+import { serializeOrdersQueryOptions } from "../../src/orders/utils";
 import { OrderSide } from "../../src/types";
 import { BAYC_CONTRACT_ADDRESS, BAYC_TOKEN_IDS } from "../utils/constants";
 import { api } from "../utils/sdk";
@@ -44,5 +45,9 @@ suite("Getting orders", () => {
       orders.map((order) => expectValidOrder(order));
       expect(next).to.not.be.undefined;
     });
+  });
+
+  test("serializeOrdersQueryOptions omits undefined tokenId", () => {
+    expect(serializeOrdersQueryOptions({}).token_ids).to.be.undefined;
   });
 });


### PR DESCRIPTION
## Summary
- avoid serializing undefined token IDs when building order query parameters so we never send `[undefined]`
- add regression test to ensure order query serialization leaves `token_ids` undefined when no IDs are provided

## Testing
- npm run check-types
- npm run eslint:check
- npm run test