### PR TITLE
Add status field to Order types

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -98,7 +98,7 @@ export enum CollectionOrderByOption {
  * Order status enum.
  * @category API Models
  */
-export enum RestOrderStatus {
+export enum OrderStatus {
   ACTIVE = "active",
   INACTIVE = "inactive",
   FULFILLED = "fulfilled",
@@ -131,7 +131,7 @@ export type Offer = Order & {
   /** The criteria for the offer if it is a collection or trait offer. */
   criteria?: Criteria;
   /** The status of the offer. */
-  status: RestOrderStatus;
+  status: OrderStatus;
 };
 
 /**
@@ -164,7 +164,7 @@ export type Listing = Omit<Order, "price"> & {
   /** The remaining quantity available for the listing. This is important for partially filled orders. */
   remaining_quantity: number;
   /** The status of the listing. */
-  status: RestOrderStatus;
+  status: OrderStatus;
 };
 
 /**

--- a/test/fixtures/listings.ts
+++ b/test/fixtures/listings.ts
@@ -1,6 +1,6 @@
 import { CROSS_CHAIN_SEAPORT_V1_6_ADDRESS } from "@opensea/seaport-js/lib/constants";
 import { mockOrderComponents } from "./orders";
-import { Listing, RestOrderStatus } from "../../src/api/types";
+import { Listing, OrderStatus } from "../../src/api/types";
 import { OrderType } from "../../src/orders/types";
 
 export const mockListing: Listing = {
@@ -20,7 +20,7 @@ export const mockListing: Listing = {
   },
   protocol_address: CROSS_CHAIN_SEAPORT_V1_6_ADDRESS,
   remaining_quantity: 1,
-  status: RestOrderStatus.ACTIVE,
+  status: OrderStatus.ACTIVE,
 };
 
 export const mockListingPartiallyFilled: Listing = {

--- a/test/fixtures/offers.ts
+++ b/test/fixtures/offers.ts
@@ -1,5 +1,5 @@
 import { mockOrderComponents } from "./orders";
-import { Offer, RestOrderStatus } from "../../src/api/types";
+import { Offer, OrderStatus } from "../../src/api/types";
 
 // eslint-disable-next-line import/no-unused-modules
 export const mockOffer: Offer = {
@@ -15,7 +15,7 @@ export const mockOffer: Offer = {
     decimals: 18,
     value: "1500000000000000000",
   },
-  status: RestOrderStatus.ACTIVE,
+  status: OrderStatus.ACTIVE,
 };
 
 // eslint-disable-next-line import/no-unused-modules


### PR DESCRIPTION
## Summary

- Add `OrderStatus` enum with values: `ACTIVE`, `INACTIVE`, `FULFILLED`, `EXPIRED`, `CANCELLED`
- Add `status` field to `Offer` type
- Add `status` field to `Listing` type
- Update test fixtures to include status field

This change aligns with the backend PR that adds order status tracking to the Get Order endpoint responses, allowing clients to easily determine the current state of orders without additional computation.

## Test plan

- [x] All existing tests pass
- [x] TypeScript type checking passes
- [x] Test fixtures updated to include status field
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)