### PR TITLE
chore: migrate npm publishing to trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC trusted publishing
+      contents: read
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
@@ -21,6 +24,4 @@ jobs:
         env:
           OPENSEA_API_KEY: ${{ secrets.OPENSEA_API_KEY }}
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Migrate from long-lived npm tokens to OIDC-based trusted publishing for improved security
- Add `id-token: write` permission for GitHub Actions to generate OIDC tokens
- Add `--provenance` flag to automatically generate provenance attestations
- Remove `NODE_AUTH_TOKEN` secret requirement

## Configuration Required
After merging, configure the trusted publisher on npmjs.com:
1. Go to package settings on npmjs.com
2. Navigate to "Trusted Publisher" section
3. Click "GitHub Actions"
4. Enter repository details:
   - Organization: ProjectOpenSea
   - Repository: opensea-js
   - Workflow filename: npm-publish.yml
   - Environment name: (leave empty)

## References
- [NPM Trusted Publishing Documentation](https://docs.npmjs.com/trusted-publishers/)
- [GitHub Changelog: NPM Trusted Publishing](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)