### PR TITLE
Fix: Use correct function for listing payment token cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "8.0.7",
+  "version": "8.0.8",
   "description": "TypeScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -28,6 +28,7 @@ import {
 import {
   getDefaultConduit,
   getOfferPaymentToken,
+  getListingPaymentToken,
   getSeaportAddress,
 } from "./utils/utils";
 
@@ -101,7 +102,9 @@ export class OpenSeaSDK {
 
     // Cache decimals for offer and listing payment tokens to skip network request
     const offerPaymentToken = getOfferPaymentToken(this.chain).toLowerCase();
-    const listingPaymentToken = getOfferPaymentToken(this.chain).toLowerCase();
+    const listingPaymentToken = getListingPaymentToken(
+      this.chain,
+    ).toLowerCase();
     this._cachedPaymentTokenDecimals[offerPaymentToken] = 18;
     this._cachedPaymentTokenDecimals[listingPaymentToken] = 18;
 


### PR DESCRIPTION
## Bug

Line 104 in `src/sdk.ts` uses `getOfferPaymentToken()` when it should use `getListingPaymentToken()`. This is a copy-paste error from line 103.

## Problem

The wrong token address gets cached for listings. On chains where listing tokens differ from offer tokens (like ETH vs WETH on mainnet), this breaks the cache and could cause issues with listing operations.

## Fix

- Changed line 104 to call `getListingPaymentToken(this.chain)` instead of `getOfferPaymentToken(this.chain)`
- Added the missing import for `getListingPaymentToken`

The rest of the codebase already uses these functions correctly - this was just a typo in the cache initialization.