### PR TITLE
Fix: Add validation for empty payment items in private listings

### DIFF
--- a/src/orders/privateListings.ts
+++ b/src/orders/privateListings.ts
@@ -28,6 +28,12 @@ export const constructPrivateListingCounterOrder = (
       item.recipient.toLowerCase() !== privateSaleRecipient.toLowerCase(),
   );
 
+  if (paymentItems.length === 0) {
+    throw new Error(
+      "The consideration for the private listing did not contain any payment items",
+    );
+  }
+
   if (!paymentItems.every((item) => isCurrencyItem(item))) {
     throw new Error(
       "The consideration for the private listing did not contain only currency items",


### PR DESCRIPTION
## Bug

In `src/orders/privateListings.ts`, the `constructPrivateListingCounterOrder` function filters payment items but doesn't check if the result is empty. Lines 37, 59-61 then access `paymentItems[0]` which would be undefined and crash.

## How it happens

1. Filter removes all consideration items going to the private sale recipient (line 26-29)
2. If ALL items go to the recipient, `paymentItems` is empty
3. Line 31 check: `paymentItems.every(...)` returns true for empty arrays (vacuous truth)
4. Lines 37, 59-61 access `paymentItems[0]` which is undefined → crash

## Fix

Added explicit length check after filtering. Now throws a descriptive error instead of crashing with undefined access.

This prevents runtime errors in edge case scenarios with malformed private listings.