### PR TITLE
Fix: Support zero-payment private listings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "8.0.8",
+  "version": "8.0.9",
   "description": "TypeScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/sdk/fulfillment.ts
+++ b/src/sdk/fulfillment.ts
@@ -5,6 +5,7 @@ import { SDKContext } from "./context";
 import { OrdersManager } from "./orders";
 import { Listing, Offer, Order } from "../api/types";
 import {
+  computePrivateListingValue,
   constructPrivateListingCounterOrder,
   getPrivateListingFulfillments,
 } from "../orders/privateListings";
@@ -60,6 +61,14 @@ export class FulfillmentManager {
       order.taker.address,
     );
     const fulfillments = getPrivateListingFulfillments(order.protocolData);
+
+    // Compute ETH value from original order's consideration items
+    // This handles both standard private listings and zero-payment listings (e.g., rewards)
+    const value = computePrivateListingValue(
+      order.protocolData,
+      order.taker.address,
+    );
+
     const seaport = getSeaportInstance(
       order.protocolAddress,
       this.context.seaport,
@@ -70,7 +79,7 @@ export class FulfillmentManager {
         fulfillments,
         overrides: {
           ...overrides,
-          value: counterOrder.parameters.offer[0].startAmount,
+          value,
         },
         accountAddress,
         domain,

--- a/test/orders/privateListings.spec.ts
+++ b/test/orders/privateListings.spec.ts
@@ -1,0 +1,300 @@
+import { ItemType } from "@opensea/seaport-js/lib/constants";
+import { OrderWithCounter } from "@opensea/seaport-js/lib/types";
+import { expect } from "chai";
+import { ZeroAddress } from "ethers";
+import { suite, test } from "mocha";
+import {
+  computePrivateListingValue,
+  constructPrivateListingCounterOrder,
+} from "../../src/orders/privateListings";
+
+const SELLER_ADDRESS = "0x1111111111111111111111111111111111111111";
+const TAKER_ADDRESS = "0x2222222222222222222222222222222222222222";
+const FEE_RECIPIENT = "0x3333333333333333333333333333333333333333";
+const NFT_CONTRACT = "0x4444444444444444444444444444444444444444";
+const WETH_ADDRESS = "0x5555555555555555555555555555555555555555";
+
+const createMockOrder = (
+  consideration: OrderWithCounter["parameters"]["consideration"],
+): OrderWithCounter => ({
+  parameters: {
+    offerer: SELLER_ADDRESS,
+    zone: ZeroAddress,
+    offer: [
+      {
+        itemType: ItemType.ERC721,
+        token: NFT_CONTRACT,
+        identifierOrCriteria: "1",
+        startAmount: "1",
+        endAmount: "1",
+      },
+    ],
+    consideration,
+    orderType: 0,
+    startTime: "0",
+    endTime: "0",
+    zoneHash:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    salt: "0",
+    conduitKey:
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+    totalOriginalConsiderationItems: consideration.length,
+    counter: "0",
+  },
+  signature: "0x",
+});
+
+suite("Orders: privateListings", () => {
+  suite("computePrivateListingValue", () => {
+    test("should return 0 for zero-payment private listings", () => {
+      const order = createMockOrder([
+        // Only NFT going to taker, no payment items
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+      ]);
+
+      const value = computePrivateListingValue(order, TAKER_ADDRESS);
+      expect(value).to.equal(0n);
+    });
+
+    test("should sum native currency items not going to taker", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // Payment to seller (1 ETH)
+        {
+          itemType: ItemType.NATIVE,
+          token: ZeroAddress,
+          identifierOrCriteria: "0",
+          startAmount: "1000000000000000000",
+          endAmount: "1000000000000000000",
+          recipient: SELLER_ADDRESS,
+        },
+        // Fee to fee recipient (0.1 ETH)
+        {
+          itemType: ItemType.NATIVE,
+          token: ZeroAddress,
+          identifierOrCriteria: "0",
+          startAmount: "100000000000000000",
+          endAmount: "100000000000000000",
+          recipient: FEE_RECIPIENT,
+        },
+      ]);
+
+      const value = computePrivateListingValue(order, TAKER_ADDRESS);
+      // 1 ETH + 0.1 ETH = 1.1 ETH
+      expect(value).to.equal(1100000000000000000n);
+    });
+
+    test("should ignore ERC20 currency items", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // WETH payment to seller (should be ignored)
+        {
+          itemType: ItemType.ERC20,
+          token: WETH_ADDRESS,
+          identifierOrCriteria: "0",
+          startAmount: "1000000000000000000",
+          endAmount: "1000000000000000000",
+          recipient: SELLER_ADDRESS,
+        },
+      ]);
+
+      const value = computePrivateListingValue(order, TAKER_ADDRESS);
+      expect(value).to.equal(0n);
+    });
+
+    test("should handle mixed native and ERC20 payments", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // Native payment to seller (0.5 ETH)
+        {
+          itemType: ItemType.NATIVE,
+          token: ZeroAddress,
+          identifierOrCriteria: "0",
+          startAmount: "500000000000000000",
+          endAmount: "500000000000000000",
+          recipient: SELLER_ADDRESS,
+        },
+        // WETH payment (should be ignored)
+        {
+          itemType: ItemType.ERC20,
+          token: WETH_ADDRESS,
+          identifierOrCriteria: "0",
+          startAmount: "500000000000000000",
+          endAmount: "500000000000000000",
+          recipient: SELLER_ADDRESS,
+        },
+      ]);
+
+      const value = computePrivateListingValue(order, TAKER_ADDRESS);
+      // Only native ETH counts
+      expect(value).to.equal(500000000000000000n);
+    });
+  });
+
+  suite("constructPrivateListingCounterOrder", () => {
+    test("should return empty offer for zero-payment private listings", () => {
+      const order = createMockOrder([
+        // Only NFT going to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+      ]);
+
+      const counterOrder = constructPrivateListingCounterOrder(
+        order,
+        TAKER_ADDRESS,
+      );
+
+      expect(counterOrder.parameters.offer).to.deep.equal([]);
+      expect(counterOrder.parameters.consideration).to.deep.equal([]);
+      expect(counterOrder.parameters.offerer).to.equal(TAKER_ADDRESS);
+    });
+
+    test("should aggregate payment items into single offer", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // Payment to seller
+        {
+          itemType: ItemType.NATIVE,
+          token: ZeroAddress,
+          identifierOrCriteria: "0",
+          startAmount: "1000000000000000000",
+          endAmount: "1000000000000000000",
+          recipient: SELLER_ADDRESS,
+        },
+        // Fee to fee recipient
+        {
+          itemType: ItemType.NATIVE,
+          token: ZeroAddress,
+          identifierOrCriteria: "0",
+          startAmount: "100000000000000000",
+          endAmount: "100000000000000000",
+          recipient: FEE_RECIPIENT,
+        },
+      ]);
+
+      const counterOrder = constructPrivateListingCounterOrder(
+        order,
+        TAKER_ADDRESS,
+      );
+
+      expect(counterOrder.parameters.offer).to.have.length(1);
+      expect(counterOrder.parameters.offer[0].itemType).to.equal(
+        ItemType.NATIVE,
+      );
+      expect(counterOrder.parameters.offer[0].startAmount).to.equal(
+        "1100000000000000000",
+      );
+      expect(counterOrder.parameters.offer[0].endAmount).to.equal(
+        "1100000000000000000",
+      );
+    });
+
+    test("should throw if payment items contain non-currency items", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // Another NFT to seller (invalid)
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "2",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: SELLER_ADDRESS,
+        },
+      ]);
+
+      expect(() =>
+        constructPrivateListingCounterOrder(order, TAKER_ADDRESS),
+      ).to.throw("did not contain only currency items");
+    });
+
+    test("should throw if payment items have mixed currency types", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // ETH to seller
+        {
+          itemType: ItemType.NATIVE,
+          token: ZeroAddress,
+          identifierOrCriteria: "0",
+          startAmount: "500000000000000000",
+          endAmount: "500000000000000000",
+          recipient: SELLER_ADDRESS,
+        },
+        // WETH to fee recipient (different currency type)
+        {
+          itemType: ItemType.ERC20,
+          token: WETH_ADDRESS,
+          identifierOrCriteria: "0",
+          startAmount: "100000000000000000",
+          endAmount: "100000000000000000",
+          recipient: FEE_RECIPIENT,
+        },
+      ]);
+
+      expect(() =>
+        constructPrivateListingCounterOrder(order, TAKER_ADDRESS),
+      ).to.throw("Not all currency items were the same");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes SDK crash when fulfilling zero-payment private listings (e.g., rewards claims).

**Closes #1832** - This PR supersedes #1832 by properly supporting zero-payment private listings instead of just throwing an error.

## Problem

The SDK crashes when fulfilling private listings with no payment consideration items:

1. `constructPrivateListingCounterOrder` accesses `paymentItems[0]` without checking if the array is empty
2. `fulfillPrivateOrder` accesses `counterOrder.parameters.offer[0].startAmount` which is undefined for zero-payment listings

## Why #1832's approach was insufficient

PR #1832 proposed throwing an error when `paymentItems` is empty. However, investigation of the backend (os2-core) revealed that **zero-payment private listings are valid** and deliberately supported:

- `PrivateListingValidationRule.kt` bypasses the `pricePerItem <= 0` check for `REWARDS_PRIVATE_LISTING_CLAIM_WALLET`
- `SeaportListingValidationRules.kt` bypasses the "must have 1-7 currency items" check for the same wallet
- `Seaport.kt:1563-1574` explicitly handles empty payment items by returning `offer: emptyList()`

The backend already handles this correctly - the SDK should too.

## Solution

Mirror the backend behavior:

1. **Allow empty payment items** - `constructPrivateListingCounterOrder` now returns a counter order with `offer: []` for zero-payment listings instead of crashing

2. **Compute value from original order** - Added `computePrivateListingValue()` that sums native currency consideration items from the original order, handling both standard and zero-payment cases

3. **Use computed value** - `fulfillPrivateOrder` now uses `computePrivateListingValue()` instead of `counterOrder.parameters.offer[0].startAmount`

## Changes

- `src/orders/privateListings.ts`:
  - Added `computePrivateListingValue()` helper function
  - Updated `constructPrivateListingCounterOrder()` to handle empty payment items

- `src/sdk/fulfillment.ts`:
  - Import and use `computePrivateListingValue()`
  - Calculate ETH value from original order instead of counter order

## Testing

- [x] All existing tests pass
- [x] Lint passes
- [x] Type check passes