### PR TITLE
feat: add uniqueItemCount to OpenSeaCollection type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "8.0.9",
+  "version": "8.0.10",
   "description": "TypeScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,6 +306,8 @@ export interface OpenSeaCollection {
   paymentTokens: OpenSeaPaymentToken[];
   /** The total supply of the collection (minted minus burned) */
   totalSupply: number;
+  /** The number of unique items in the collection */
+  uniqueItemCount: number;
   /** The created date of the collection */
   createdDate: string;
   /** When defined, the zone required for orders for the collection */

--- a/src/utils/converters.ts
+++ b/src/utils/converters.ts
@@ -43,6 +43,7 @@ export const collectionFromJSON = (collection: any): OpenSeaCollection => {
     rarity: rarityFromJSON(collection.rarity),
     paymentTokens: (collection.payment_tokens ?? []).map(paymentTokenFromJSON),
     totalSupply: collection.total_supply,
+    uniqueItemCount: collection.unique_item_count,
     createdDate: collection.created_date,
     requiredZone: collection.required_zone,
   };

--- a/test/fixtures/collections.ts
+++ b/test/fixtures/collections.ts
@@ -27,6 +27,7 @@ export const mockCollection: OpenSeaCollection = {
   rarity: null,
   paymentTokens: [],
   totalSupply: 10000,
+  uniqueItemCount: 10000,
   createdDate: "2024-01-01T00:00:00Z",
 };
 


### PR DESCRIPTION
Adds `uniqueItemCount` field to the `OpenSeaCollection` type to match the backend API response.

## Changes
- Added `uniqueItemCount: number` to `OpenSeaCollection` interface in `src/types.ts`
- Updated `collectionFromJSON` converter to map `unique_item_count` from API response
- Updated test fixtures
- Bumped version to 8.0.10