### PR TITLE
fix: use chain-specific seaport address for collection offers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "8.0.11",
+  "version": "8.0.12",
   "description": "TypeScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/api/offers.ts
+++ b/src/api/offers.ts
@@ -128,6 +128,7 @@ export class OffersAPI {
       quantity,
       collectionSlug,
       offerProtectionEnabled,
+      this.chain,
       traitType,
       traitValue,
       traits,
@@ -169,6 +170,7 @@ export class OffersAPI {
     const payload = getPostCollectionOfferPayload(
       slug,
       order,
+      this.chain,
       traitType,
       traitValue,
       traits,

--- a/src/orders/utils.ts
+++ b/src/orders/utils.ts
@@ -6,7 +6,7 @@ import {
   ProtocolData,
 } from "./types";
 import { Chain, OrderSide } from "../types";
-import { accountFromJSON } from "../utils";
+import { accountFromJSON, getSeaportAddress } from "../utils";
 
 export const DEFAULT_SEAPORT_CONTRACT_ADDRESS =
   CROSS_CHAIN_SEAPORT_V1_6_ADDRESS;
@@ -14,6 +14,7 @@ export const DEFAULT_SEAPORT_CONTRACT_ADDRESS =
 export const getPostCollectionOfferPayload = (
   collectionSlug: string,
   protocol_data: ProtocolData,
+  chain: Chain,
   traitType?: string,
   traitValue?: string,
   traits?: Array<{ type: string; value: string }>,
@@ -23,7 +24,7 @@ export const getPostCollectionOfferPayload = (
       collection: { slug: collectionSlug },
     },
     protocol_data,
-    protocol_address: DEFAULT_SEAPORT_CONTRACT_ADDRESS,
+    protocol_address: getSeaportAddress(chain),
   };
 
   // Prioritize traits array if provided
@@ -46,6 +47,7 @@ export const getBuildCollectionOfferPayload = (
   quantity: number,
   collectionSlug: string,
   offerProtectionEnabled: boolean,
+  chain: Chain,
   traitType?: string,
   traitValue?: string,
   traits?: Array<{ type: string; value: string }>,
@@ -58,7 +60,7 @@ export const getBuildCollectionOfferPayload = (
         slug: collectionSlug,
       },
     },
-    protocol_address: DEFAULT_SEAPORT_CONTRACT_ADDRESS,
+    protocol_address: getSeaportAddress(chain),
     offer_protection_enabled: offerProtectionEnabled,
   };
 

--- a/test/orders/utils.spec.ts
+++ b/test/orders/utils.spec.ts
@@ -116,6 +116,7 @@ suite("Orders: utils", () => {
       const result = getPostCollectionOfferPayload(
         "boredapeyachtclub",
         protocolData,
+        Chain.Mainnet,
       );
 
       expect(result).to.deep.equal({
@@ -133,6 +134,7 @@ suite("Orders: utils", () => {
       const result = getPostCollectionOfferPayload(
         "boredapeyachtclub",
         protocolData,
+        Chain.Mainnet,
         "Background",
         "Blue",
       );
@@ -151,6 +153,7 @@ suite("Orders: utils", () => {
       const result = getPostCollectionOfferPayload(
         "boredapeyachtclub",
         protocolData,
+        Chain.Mainnet,
         "Background",
       );
 
@@ -164,6 +167,7 @@ suite("Orders: utils", () => {
       const result = getPostCollectionOfferPayload(
         "boredapeyachtclub",
         protocolData,
+        Chain.Mainnet,
         undefined,
         "Blue",
       );
@@ -182,6 +186,7 @@ suite("Orders: utils", () => {
       const result = getPostCollectionOfferPayload(
         "boredapeyachtclub",
         protocolData,
+        Chain.Mainnet,
         undefined,
         undefined,
         traits,
@@ -202,6 +207,7 @@ suite("Orders: utils", () => {
       const result = getPostCollectionOfferPayload(
         "boredapeyachtclub",
         protocolData,
+        Chain.Mainnet,
         "Fur",
         "Brown",
         traits,
@@ -220,6 +226,7 @@ suite("Orders: utils", () => {
       const result = getPostCollectionOfferPayload(
         "boredapeyachtclub",
         protocolData,
+        Chain.Mainnet,
         undefined,
         undefined,
         [],
@@ -239,6 +246,7 @@ suite("Orders: utils", () => {
         5,
         "boredapeyachtclub",
         true,
+        Chain.Mainnet,
       );
 
       expect(result).to.deep.equal({
@@ -260,6 +268,7 @@ suite("Orders: utils", () => {
         3,
         "boredapeyachtclub",
         false,
+        Chain.Mainnet,
         "Hat",
         "Crown",
       );
@@ -283,6 +292,7 @@ suite("Orders: utils", () => {
         2,
         "boredapeyachtclub",
         true,
+        Chain.Mainnet,
         undefined,
         undefined,
         traits,
@@ -303,6 +313,7 @@ suite("Orders: utils", () => {
         1,
         "boredapeyachtclub",
         false,
+        Chain.Mainnet,
         "Hat",
         "Crown",
         traits,
@@ -321,6 +332,7 @@ suite("Orders: utils", () => {
         5,
         "boredapeyachtclub",
         true,
+        Chain.Mainnet,
         undefined,
         undefined,
         [],


### PR DESCRIPTION
## Summary

- Fixed collection offers failing on Somnia and Gunzilla chains with "execution reverted" error
- The `getPostCollectionOfferPayload` and `getBuildCollectionOfferPayload` functions were hardcoded to use the standard cross-chain Seaport address (`0x0000000000000068f116a894984e2db1123eb395`) instead of the chain-specific address
- Updated both functions to accept a `chain` parameter and use `getSeaportAddress(chain)` to determine the correct protocol address
- Somnia and Gunzilla use a different Seaport contract: `0x00000000006687982678b03100B9bDC8be440814`

## Root Cause

When creating collection offers, the SDK was sending the wrong `protocol_address` in the API payload:
- Orders were **signed** with the correct chain-specific Seaport address
- But the API payload contained the **hardcoded** standard Seaport address
- The OpenSea validator then tried to validate the order against the wrong contract, causing "execution reverted"

## Test plan

- [x] Unit tests updated and passing
- [x] Manually tested collection offer creation on Somnia mainnet - now works

Fixes: https://github.com/ProjectOpenSea/opensea-js/discussions/1848

---
🤖 Generated with [Claude Code](https://claude.ai/code)