### PR TITLE
fix: normalize protocol address checksums

### DIFF
--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -83,9 +83,15 @@ export const getSeaportInstance = (
 ): Seaport => {
   try {
     const checksummedProtocolAddress = ethers.getAddress(protocolAddress);
+
+    const crossChainSeaportAddress = ethers.getAddress(
+      CROSS_CHAIN_SEAPORT_V1_6_ADDRESS,
+    );
+    const gunzillaSeaportAddress = ethers.getAddress(GUNZILLA_SEAPORT_1_6_ADDRESS);
+
     switch (checksummedProtocolAddress) {
-      case CROSS_CHAIN_SEAPORT_V1_6_ADDRESS:
-      case GUNZILLA_SEAPORT_1_6_ADDRESS:
+      case crossChainSeaportAddress:
+      case gunzillaSeaportAddress:
         return seaport;
       default:
         throw new Error(`Unsupported protocol address: ${protocolAddress}`);
@@ -111,9 +117,15 @@ export const getSeaportInstance = (
 export const getSeaportVersion = (protocolAddress: string): string => {
   try {
     const protocolAddressChecksummed = ethers.getAddress(protocolAddress);
+
+    const crossChainSeaportAddress = ethers.getAddress(
+      CROSS_CHAIN_SEAPORT_V1_6_ADDRESS,
+    );
+    const gunzillaSeaportAddress = ethers.getAddress(GUNZILLA_SEAPORT_1_6_ADDRESS);
+
     switch (protocolAddressChecksummed) {
-      case CROSS_CHAIN_SEAPORT_V1_6_ADDRESS:
-      case GUNZILLA_SEAPORT_1_6_ADDRESS:
+      case crossChainSeaportAddress:
+      case gunzillaSeaportAddress:
         return "1.6";
       default:
         throw new Error(


### PR DESCRIPTION
## Motivation
The SDK compares a checksummed protocolAddress (via ethers.getAddress) against protocol constants that may not be checksummed (e.g. lowercase). Because the comparison was done as a raw string match, valid protocol addresses could be incorrectly treated as unsupported purely due to address formatting/casing differences.

## Solution
Normalize the known protocol constants using ethers.getAddress() before performing comparisons in getSeaportInstance and getSeaportVersion. This ensures all comparisons are checksum-consistent and prevents false negatives when resolving supported protocol addresses/versions.