### PR TITLE
fix: prettier formatting and bump version to 8.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensea-js",
-  "version": "8.0.6",
+  "version": "8.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensea-js",
-      "version": "8.0.6",
+      "version": "8.0.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensea-js",
-  "version": "8.0.12",
+  "version": "8.0.13",
   "description": "TypeScript SDK for the OpenSea marketplace helps developers build new experiences using NFTs and our marketplace data",
   "license": "MIT",
   "author": "OpenSea Developers",

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -87,7 +87,9 @@ export const getSeaportInstance = (
     const crossChainSeaportAddress = ethers.getAddress(
       CROSS_CHAIN_SEAPORT_V1_6_ADDRESS,
     );
-    const gunzillaSeaportAddress = ethers.getAddress(GUNZILLA_SEAPORT_1_6_ADDRESS);
+    const gunzillaSeaportAddress = ethers.getAddress(
+      GUNZILLA_SEAPORT_1_6_ADDRESS,
+    );
 
     switch (checksummedProtocolAddress) {
       case crossChainSeaportAddress:
@@ -121,7 +123,9 @@ export const getSeaportVersion = (protocolAddress: string): string => {
     const crossChainSeaportAddress = ethers.getAddress(
       CROSS_CHAIN_SEAPORT_V1_6_ADDRESS,
     );
-    const gunzillaSeaportAddress = ethers.getAddress(GUNZILLA_SEAPORT_1_6_ADDRESS);
+    const gunzillaSeaportAddress = ethers.getAddress(
+      GUNZILLA_SEAPORT_1_6_ADDRESS,
+    );
 
     switch (protocolAddressChecksummed) {
       case crossChainSeaportAddress:


### PR DESCRIPTION
## Summary
- Fix prettier formatting issues in `src/utils/protocol.ts`
- Bump patch version from 8.0.12 to 8.0.13

## Test plan
- [x] Lint passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)