### PR TITLE
refactor: cleanup naming conventions and add usesAlternateProtocol helper

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,14 +32,12 @@ export const OPENSEA_CONDUIT_KEY_2 =
 export const OPENSEA_CONDUIT_ADDRESS_2 =
   "0x963f00d3ff000064ffcba824b800c0000000c300";
 
-export const SIGNED_ZONE = "0x000056f7000000ece9003ca63978907a00ffd100";
+export const OPENSEA_SIGNED_ZONE_V2 =
+  "0x000056f7000000ece9003ca63978907a00ffd100";
 
 // =============================================================================
-// Alternate Protocol Constants (used by Gunzilla, Somnia, etc.)
+// Alternate Protocol Constants (shared by Gunzilla, Somnia, etc.)
 // =============================================================================
-
-export const ALTERNATE_FEE_RECIPIENT =
-  "0xd9f68d28e451a83affdb7c71cc2c20552555b07f";
 
 export const ALTERNATE_CONDUIT_ADDRESS =
   "0x00000000001566479594a2e05532d81afa09bc52";
@@ -54,8 +52,11 @@ export const ALTERNATE_SIGNED_ZONE_V2_ADDRESS =
   "0xdfe0000000005ce3008800300037e4c803ed08c7";
 
 // =============================================================================
-// Somnia-Specific Constants
+// Chain-Specific Fee Recipients
 // =============================================================================
+
+export const GUNZILLA_FEE_RECIPIENT =
+  "0xd9f68d28e451a83affdb7c71cc2c20552555b07f";
 
 export const SOMNIA_FEE_RECIPIENT =
   "0xdfe1593dca6ad8a20eeb418643e48577c1626f7c";

--- a/src/sdk/orders.ts
+++ b/src/sdk/orders.ts
@@ -19,7 +19,7 @@ import { oneMonthFromNowInSeconds } from "../utils/dateHelper";
 import { pluralize } from "../utils/stringHelper";
 import {
   getAssetItemType,
-  getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress,
+  remapSharedStorefrontAddress,
   basisPointsForFee,
   totalBasisPointsForFees,
   getFeeRecipient,
@@ -82,10 +82,7 @@ export class OrdersManager {
       itemType: getAssetItemType(
         nft.token_standard.toUpperCase() as TokenStandard,
       ),
-      token:
-        getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-          nft.contract,
-        ),
+      token: remapSharedStorefrontAddress(nft.contract),
       identifier: nft.identifier ?? undefined,
       amount: quantities[index].toString() ?? "1",
     }));

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -2,7 +2,7 @@ import { CROSS_CHAIN_SEAPORT_V1_6_ADDRESS } from "@opensea/seaport-js/lib/consta
 import {
   ALTERNATE_CONDUIT_ADDRESS,
   ALTERNATE_CONDUIT_KEY,
-  ALTERNATE_FEE_RECIPIENT,
+  GUNZILLA_FEE_RECIPIENT,
   ALTERNATE_SEAPORT_V1_6_ADDRESS,
   ALTERNATE_SIGNED_ZONE_V2_ADDRESS,
   OPENSEA_CONDUIT_ADDRESS,
@@ -10,11 +10,20 @@ import {
   OPENSEA_CONDUIT_KEY,
   OPENSEA_CONDUIT_KEY_2,
   OPENSEA_FEE_RECIPIENT,
-  SIGNED_ZONE,
+  OPENSEA_SIGNED_ZONE_V2,
   SOMNIA_FEE_RECIPIENT,
   WPOL_ADDRESS,
 } from "../constants";
 import { Chain } from "../types";
+
+/**
+ * Checks if a chain uses the alternate protocol addresses.
+ * These chains use non-standard Seaport, conduit, and signed zone deployments.
+ * @param chain The chain to check
+ * @returns True if the chain uses alternate protocol addresses
+ */
+export const usesAlternateProtocol = (chain: Chain): boolean =>
+  chain === Chain.Gunzilla || chain === Chain.Somnia;
 
 /**
  * Gets the chain ID for a given chain.
@@ -178,13 +187,13 @@ export const getDefaultConduit = (
         key: OPENSEA_CONDUIT_KEY_2,
         address: OPENSEA_CONDUIT_ADDRESS_2,
       };
-    case Chain.Gunzilla:
-    case Chain.Somnia:
-      return {
-        key: ALTERNATE_CONDUIT_KEY,
-        address: ALTERNATE_CONDUIT_ADDRESS,
-      };
     default:
+      if (usesAlternateProtocol(chain)) {
+        return {
+          key: ALTERNATE_CONDUIT_KEY,
+          address: ALTERNATE_CONDUIT_ADDRESS,
+        };
+      }
       return {
         key: OPENSEA_CONDUIT_KEY,
         address: OPENSEA_CONDUIT_ADDRESS,
@@ -198,13 +207,9 @@ export const getDefaultConduit = (
  * @returns The Seaport 1.6 address for the chain
  */
 export const getSeaportAddress = (chain: Chain): string => {
-  switch (chain) {
-    case Chain.Gunzilla:
-    case Chain.Somnia:
-      return ALTERNATE_SEAPORT_V1_6_ADDRESS;
-    default:
-      return CROSS_CHAIN_SEAPORT_V1_6_ADDRESS;
-  }
+  return usesAlternateProtocol(chain)
+    ? ALTERNATE_SEAPORT_V1_6_ADDRESS
+    : CROSS_CHAIN_SEAPORT_V1_6_ADDRESS;
 };
 
 /**
@@ -213,13 +218,9 @@ export const getSeaportAddress = (chain: Chain): string => {
  * @returns The signed zone address for the chain
  */
 export const getSignedZone = (chain: Chain): string => {
-  switch (chain) {
-    case Chain.Gunzilla:
-    case Chain.Somnia:
-      return ALTERNATE_SIGNED_ZONE_V2_ADDRESS;
-    default:
-      return SIGNED_ZONE;
-  }
+  return usesAlternateProtocol(chain)
+    ? ALTERNATE_SIGNED_ZONE_V2_ADDRESS
+    : OPENSEA_SIGNED_ZONE_V2;
 };
 
 /**
@@ -230,7 +231,7 @@ export const getSignedZone = (chain: Chain): string => {
 export const getFeeRecipient = (chain: Chain): string => {
   switch (chain) {
     case Chain.Gunzilla:
-      return ALTERNATE_FEE_RECIPIENT;
+      return GUNZILLA_FEE_RECIPIENT;
     case Chain.Somnia:
       return SOMNIA_FEE_RECIPIENT;
     default:

--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -36,17 +36,21 @@ export const getAssetItemType = (tokenStandard: TokenStandard) => {
 };
 
 /**
- * Checks if the token address is the shared storefront address and if so replaces
- * that address with the lazy mint adapter address. Otherwise, returns the input token address
- * @param tokenAddress token address
- * @returns input token address or lazy mint adapter address
+ * Remaps shared storefront token addresses to the lazy mint adapter address.
+ *
+ * OpenSea's shared storefront contracts require special handling - when a token
+ * is from a shared storefront address, it must be remapped to the lazy mint
+ * adapter address for proper Seaport order creation.
+ *
+ * @param tokenAddress The token contract address to check
+ * @returns The lazy mint adapter address if the input is a shared storefront address,
+ *          otherwise returns the original address unchanged
  */
-export const getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress =
-  (tokenAddress: string): string => {
-    return SHARED_STOREFRONT_ADDRESSES.includes(tokenAddress.toLowerCase())
-      ? SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS
-      : tokenAddress;
-  };
+export const remapSharedStorefrontAddress = (tokenAddress: string): string => {
+  return SHARED_STOREFRONT_ADDRESSES.includes(tokenAddress.toLowerCase())
+    ? SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS
+    : tokenAddress;
+};
 
 /**
  * Returns if a protocol address is valid.

--- a/test/sdk/misc.spec.ts
+++ b/test/sdk/misc.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/constants";
 import {
   decodeTokenIds,
-  getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress,
+  remapSharedStorefrontAddress,
 } from "../../src/utils/utils";
 import { BAYC_CONTRACT_ADDRESS } from "../utils/constants";
 import { sdk } from "../utils/sdk";
@@ -24,20 +24,13 @@ suite("SDK: misc", () => {
 
   test("Checks that a non-shared storefront address is not remapped", async () => {
     const address = BAYC_CONTRACT_ADDRESS;
-    assert.equal(
-      getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-        address,
-      ),
-      address,
-    );
+    assert.equal(remapSharedStorefrontAddress(address), address);
   });
 
   test("Checks that shared storefront addresses are remapped to lazy mint adapter address", async () => {
     for (const address of SHARED_STOREFRONT_ADDRESSES) {
       assert.equal(
-        getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-          address,
-        ),
+        remapSharedStorefrontAddress(address),
         SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
       );
     }
@@ -46,9 +39,7 @@ suite("SDK: misc", () => {
   test("Checks that upper case shared storefront addresses are remapped to lazy mint adapter address", async () => {
     for (const address of SHARED_STOREFRONT_ADDRESSES) {
       assert.equal(
-        getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-          address.toUpperCase(),
-        ),
+        remapSharedStorefrontAddress(address.toUpperCase()),
         SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
       );
     }

--- a/test/utils/chain.spec.ts
+++ b/test/utils/chain.spec.ts
@@ -10,9 +10,9 @@ import {
   ALTERNATE_CONDUIT_ADDRESS,
   ALTERNATE_SEAPORT_V1_6_ADDRESS,
   ALTERNATE_SIGNED_ZONE_V2_ADDRESS,
-  SIGNED_ZONE,
+  OPENSEA_SIGNED_ZONE_V2,
   OPENSEA_FEE_RECIPIENT,
-  ALTERNATE_FEE_RECIPIENT,
+  GUNZILLA_FEE_RECIPIENT,
   SOMNIA_FEE_RECIPIENT,
 } from "../../src/constants";
 import { Chain } from "../../src/types";
@@ -342,7 +342,7 @@ suite("Utils: chain", () => {
 
   suite("getSignedZone", () => {
     test("returns OpenSea signed zone for Mainnet", () => {
-      expect(getSignedZone(Chain.Mainnet)).to.equal(SIGNED_ZONE);
+      expect(getSignedZone(Chain.Mainnet)).to.equal(OPENSEA_SIGNED_ZONE_V2);
     });
 
     test("returns alternate signed zone for Gunzilla", () => {
@@ -366,7 +366,7 @@ suite("Utils: chain", () => {
       ];
 
       for (const chain of otherChains) {
-        expect(getSignedZone(chain)).to.equal(SIGNED_ZONE);
+        expect(getSignedZone(chain)).to.equal(OPENSEA_SIGNED_ZONE_V2);
       }
     });
   });
@@ -376,8 +376,8 @@ suite("Utils: chain", () => {
       expect(getFeeRecipient(Chain.Mainnet)).to.equal(OPENSEA_FEE_RECIPIENT);
     });
 
-    test("returns alternate fee recipient for Gunzilla", () => {
-      expect(getFeeRecipient(Chain.Gunzilla)).to.equal(ALTERNATE_FEE_RECIPIENT);
+    test("returns Gunzilla fee recipient for Gunzilla", () => {
+      expect(getFeeRecipient(Chain.Gunzilla)).to.equal(GUNZILLA_FEE_RECIPIENT);
     });
 
     test("returns Somnia fee recipient for Somnia", () => {

--- a/test/utils/protocol.spec.ts
+++ b/test/utils/protocol.spec.ts
@@ -17,7 +17,7 @@ import {
   isValidProtocol,
   requireValidProtocol,
   getAssetItemType,
-  getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress,
+  remapSharedStorefrontAddress,
   decodeTokenIds,
   getSeaportInstance,
   getSeaportVersion,
@@ -111,44 +111,32 @@ suite("Utils: protocol", () => {
     });
   });
 
-  suite(
-    "getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress",
-    () => {
-      test("returns lazy mint adapter address for shared storefront address", () => {
-        for (const sharedStorefrontAddress of SHARED_STOREFRONT_ADDRESSES) {
-          const result =
-            getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-              sharedStorefrontAddress,
-            );
-          expect(result).to.equal(
-            SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
-          );
-        }
-      });
+  suite("remapSharedStorefrontAddress", () => {
+    test("returns lazy mint adapter address for shared storefront address", () => {
+      for (const sharedStorefrontAddress of SHARED_STOREFRONT_ADDRESSES) {
+        const result = remapSharedStorefrontAddress(sharedStorefrontAddress);
+        expect(result).to.equal(
+          SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
+        );
+      }
+    });
 
-      test("returns lazy mint adapter address for uppercase shared storefront address", () => {
-        for (const sharedStorefrontAddress of SHARED_STOREFRONT_ADDRESSES) {
-          const upperCaseAddress = sharedStorefrontAddress.toUpperCase();
-          const result =
-            getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-              upperCaseAddress,
-            );
-          expect(result).to.equal(
-            SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
-          );
-        }
-      });
+    test("returns lazy mint adapter address for uppercase shared storefront address", () => {
+      for (const sharedStorefrontAddress of SHARED_STOREFRONT_ADDRESSES) {
+        const upperCaseAddress = sharedStorefrontAddress.toUpperCase();
+        const result = remapSharedStorefrontAddress(upperCaseAddress);
+        expect(result).to.equal(
+          SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
+        );
+      }
+    });
 
-      test("returns original address for non-shared storefront address", () => {
-        const randomAddress = ethers.Wallet.createRandom().address;
-        const result =
-          getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress(
-            randomAddress,
-          );
-        expect(result).to.equal(randomAddress);
-      });
-    },
-  );
+    test("returns original address for non-shared storefront address", () => {
+      const randomAddress = ethers.Wallet.createRandom().address;
+      const result = remapSharedStorefrontAddress(randomAddress);
+      expect(result).to.equal(randomAddress);
+    });
+  });
 
   suite("decodeTokenIds", () => {
     test("returns ['*'] when given '*' as input", () => {


### PR DESCRIPTION
## Summary
- Rename `SIGNED_ZONE` to `OPENSEA_SIGNED_ZONE_V2` for consistency with other OpenSea constants
- Add `usesAlternateProtocol()` helper to reduce repeated `Chain.Gunzilla || Chain.Somnia` checks
- Rename `getAddressAfterRemappingSharedStorefrontAddressToLazyMintAdapterAddress` to `remapSharedStorefrontAddress` with improved documentation
- Keep `GUNZILLA_FEE_RECIPIENT` as chain-specific (Somnia has its own `SOMNIA_FEE_RECIPIENT`)
- Reorganize constants into clearer sections:
  - `ALTERNATE_*` for shared protocol constants (conduit, seaport, signed zone)
  - Chain-specific fee recipients in separate section

## Test plan
- [x] Lint passes
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)