### PR TITLE
Clarify private order visibility

### DIFF
--- a/developerDocs/advanced-use-cases.md
+++ b/developerDocs/advanced-use-cases.md
@@ -61,7 +61,7 @@ const listing = await openseaSDK.createListing({
 ```
 
 **Important**  
-> Private orders restrict who can fulfill the order, but the order itself may still be visible onchain or via OpenSea APIs.
+> Private orders only restrict the taker address at the contract level. The order data remains public and discoverable via OpenSea APIs and on-chain indexers.
 
 ### Canceling Orders
 


### PR DESCRIPTION
Added a note that private orders only restrict fulfillment (the taker), but remain public via API/on-chain.