### PR TITLE
fix(utils): Make decodeTokenIds tolerant to whitespace around delimiters.

### DIFF
--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -161,30 +161,34 @@ export const getSeaportVersion = (protocolAddress: string): string => {
  * const decodedEmpty = decodeTokenIds(emptyEncoded); // Output: []
  */
 export const decodeTokenIds = (encodedTokenIds: string): string[] => {
-  if (encodedTokenIds === "*") {
+  const trimmedEncodedTokenIds = encodedTokenIds.trim();
+
+  if (trimmedEncodedTokenIds === "*") {
     return ["*"];
   }
 
-  if (encodedTokenIds === "") {
+  if (trimmedEncodedTokenIds === "") {
     return [];
   }
 
-  const validFormatRegex = /^(\d+(:\d+)?)(,\d+(:\d+)?)*$/;
+  const validFormatRegex =
+    /^(\s*\d+\s*(\s*:\s*\d+\s*)?)(\s*,\s*\d+\s*(\s*:\s*\d+\s*)?)*\s*$/;
 
-  if (!validFormatRegex.test(encodedTokenIds)) {
+  if (!validFormatRegex.test(trimmedEncodedTokenIds)) {
     throw new Error(
       "Invalid input format. Expected a valid comma-separated list of numbers and ranges.",
     );
   }
 
-  const ranges = encodedTokenIds.split(",");
+  const ranges = trimmedEncodedTokenIds.split(",");
   const tokenIds: string[] = [];
 
   for (const range of ranges) {
-    if (range.includes(":")) {
-      const [startStr, endStr] = range.split(":");
-      const start = BigInt(startStr);
-      const end = BigInt(endStr);
+    const trimmedRange = range.trim();
+    if (trimmedRange.includes(":")) {
+      const [startStr, endStr] = trimmedRange.split(":");
+      const start = BigInt(startStr.trim());
+      const end = BigInt(endStr.trim());
       const diff = end - start + 1n;
 
       if (diff <= 0) {
@@ -197,7 +201,7 @@ export const decodeTokenIds = (encodedTokenIds: string): string[] => {
         tokenIds.push((start + i).toString());
       }
     } else {
-      const tokenId = BigInt(range);
+      const tokenId = BigInt(trimmedRange);
       tokenIds.push(tokenId.toString());
     }
   }

--- a/test/utils/protocol.spec.ts
+++ b/test/utils/protocol.spec.ts
@@ -192,6 +192,16 @@ suite("Utils: protocol", () => {
       ]);
     });
 
+    test("supports whitespace around delimiters", () => {
+      expect(decodeTokenIds(" 1, 3:5, 8 ")).to.deep.equal([
+        "1",
+        "3",
+        "4",
+        "5",
+        "8",
+      ]);
+    });
+
     test("handles very large numbers", () => {
       const largeNum = "999999999999999999999999999999";
       expect(decodeTokenIds(largeNum)).to.deep.equal([largeNum]);


### PR DESCRIPTION
## Motivation

_decodeTokenIds_ rejects valid user input that includes whitespace around commas/colons (e.g. " 1, 3:5, 8 "), even though the underlying token id/range format is otherwise correct. This makes it easy for consumers to hit avoidable “Invalid input format” errors.

## Solution

Trim the input, allow whitespace around delimiters in the validation regex, and trim each segment/range part before BigInt parsing. **Add a unit test** to cover whitespace handling.