### PR TITLE
refactor: DRY up duplicate remapSharedStorefrontAddress and decodeTokenIds tests

### DIFF
--- a/test/sdk/misc.spec.ts
+++ b/test/sdk/misc.spec.ts
@@ -1,16 +1,9 @@
 import { assert, expect } from "chai";
 import { ethers } from "ethers";
 import { suite, test } from "mocha";
-import {
-  SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
-  SHARED_STOREFRONT_ADDRESSES,
-} from "../../src/constants";
-import {
-  decodeTokenIds,
-  remapSharedStorefrontAddress,
-} from "../../src/utils/utils";
-import { BAYC_CONTRACT_ADDRESS } from "../utils/constants";
 import { sdk } from "../utils/sdk";
+
+// Note: remapSharedStorefrontAddress and decodeTokenIds tests are in test/utils/protocol.spec.ts
 
 suite("SDK: misc", () => {
   test("Instance has public methods", () => {
@@ -20,29 +13,6 @@ suite("SDK: misc", () => {
   test("Instance exposes API methods", () => {
     assert.equal(typeof sdk.api.getOrder, "function");
     assert.equal(typeof sdk.api.getOrders, "function");
-  });
-
-  test("Checks that a non-shared storefront address is not remapped", async () => {
-    const address = BAYC_CONTRACT_ADDRESS;
-    assert.equal(remapSharedStorefrontAddress(address), address);
-  });
-
-  test("Checks that shared storefront addresses are remapped to lazy mint adapter address", async () => {
-    for (const address of SHARED_STOREFRONT_ADDRESSES) {
-      assert.equal(
-        remapSharedStorefrontAddress(address),
-        SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
-      );
-    }
-  });
-
-  test("Checks that upper case shared storefront addresses are remapped to lazy mint adapter address", async () => {
-    for (const address of SHARED_STOREFRONT_ADDRESSES) {
-      assert.equal(
-        remapSharedStorefrontAddress(address.toUpperCase()),
-        SHARED_STOREFRONT_LAZY_MINT_ADAPTER_CROSS_CHAIN_ADDRESS,
-      );
-    }
   });
 
   test("Should throw an error when using methods that need a provider or wallet with the accountAddress", async () => {
@@ -120,76 +90,5 @@ suite("SDK: misc", () => {
       expect(e.message).to.include(expectedErrorMessage);
     }
     /* eslint-enable @typescript-eslint/no-explicit-any */
-  });
-
-  describe("decodeTokenIds", () => {
-    it('should return ["*"] when given "*" as input', () => {
-      expect(decodeTokenIds("*")).to.deep.equal(["*"]);
-    });
-
-    it("should return [] when given empty string as input", () => {
-      expect(decodeTokenIds("")).to.deep.equal([]);
-    });
-
-    it("should correctly decode a single number", () => {
-      expect(decodeTokenIds("123")).to.deep.equal(["123"]);
-    });
-
-    it("should correctly decode multiple comma-separated numbers", () => {
-      expect(decodeTokenIds("1,2,3,4")).to.deep.equal(["1", "2", "3", "4"]);
-    });
-
-    it("should correctly decode a single number", () => {
-      expect(decodeTokenIds("10:10")).to.deep.equal(["10"]);
-    });
-
-    it("should correctly decode a range of numbers", () => {
-      expect(decodeTokenIds("5:8")).to.deep.equal(["5", "6", "7", "8"]);
-    });
-
-    it("should correctly decode multiple ranges of numbers", () => {
-      expect(decodeTokenIds("1:3,7:9")).to.deep.equal([
-        "1",
-        "2",
-        "3",
-        "7",
-        "8",
-        "9",
-      ]);
-    });
-
-    it("should correctly decode a mix of single numbers and ranges", () => {
-      expect(decodeTokenIds("1,3:5,8")).to.deep.equal([
-        "1",
-        "3",
-        "4",
-        "5",
-        "8",
-      ]);
-    });
-
-    it("should throw an error for invalid input format", () => {
-      expect(() => decodeTokenIds("1:3:5,8")).to.throw(
-        "Invalid input format. Expected a valid comma-separated list of numbers and ranges.",
-      );
-      expect(() => decodeTokenIds("1;3:5,8")).to.throw(
-        "Invalid input format. Expected a valid comma-separated list of numbers and ranges.",
-      );
-    });
-
-    it("should throw an error for invalid range format", () => {
-      expect(() => decodeTokenIds("5:2")).throws(
-        "Invalid range. End value: 2 must be greater than or equal to the start value: 5.",
-      );
-    });
-
-    it("should handle very large input numbers", () => {
-      const encoded = "10000000000000000000000000:10000000000000000000000002";
-      expect(decodeTokenIds(encoded)).deep.equal([
-        "10000000000000000000000000",
-        "10000000000000000000000001",
-        "10000000000000000000000002",
-      ]);
-    });
   });
 });


### PR DESCRIPTION
## Summary
- Remove 14 duplicate tests from `test/sdk/misc.spec.ts` that are already covered more comprehensively in `test/utils/protocol.spec.ts`
- Tests for `remapSharedStorefrontAddress` (3 tests) and `decodeTokenIds` (11 tests) were duplicated across both files
- The protocol.spec.ts versions are more comprehensive and include additional edge cases

## Test plan
- [x] All tests pass (`npm test`)
- [x] No functionality changed, just removed duplicate test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)