### PR TITLE
fix(utils): reject whitespace in decodeTokenIds with helpful error

### DIFF
--- a/src/utils/protocol.ts
+++ b/src/utils/protocol.ts
@@ -140,6 +140,13 @@ export const decodeTokenIds = (encodedTokenIds: string): string[] => {
     return [];
   }
 
+  // Check for whitespace and provide helpful error message
+  if (/\s/.test(encodedTokenIds)) {
+    throw new Error(
+      "Invalid input format: whitespace is not allowed. Expected format: '1,2,3' or '1:5' or '1,3:5,8' (no spaces).",
+    );
+  }
+
   const validFormatRegex = /^(\d+(:\d+)?)(,\d+(:\d+)?)*$/;
 
   if (!validFormatRegex.test(encodedTokenIds)) {

--- a/test/utils/protocol.spec.ts
+++ b/test/utils/protocol.spec.ts
@@ -211,6 +211,18 @@ suite("Utils: protocol", () => {
     test("correctly decodes range where start = end", () => {
       expect(decodeTokenIds("5:5")).to.deep.equal(["5"]);
     });
+
+    test("throws error for input with whitespace", () => {
+      expect(() => decodeTokenIds(" 1,2,3")).to.throw(
+        "whitespace is not allowed",
+      );
+      expect(() => decodeTokenIds("1 : 3")).to.throw(
+        "whitespace is not allowed",
+      );
+      expect(() => decodeTokenIds("1, 2")).to.throw(
+        "whitespace is not allowed",
+      );
+    });
   });
 
   suite("getSeaportInstance", () => {


### PR DESCRIPTION
## Summary
- Rejects input containing whitespace with a clear error message
- Error message shows the expected format: `'1,2,3' or '1:5' or '1,3:5,8' (no spaces)`

## Changes
- Add whitespace check that throws a descriptive error
- Add unit test verifying whitespace rejection

## Test plan
- [x] All existing tests pass (553 passing)
- [x] New test verifies whitespace is rejected with helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)