### PR TITLE
fix(fees): Handle scientific notation when converting fee percentages to basis points

### DIFF
--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -2,6 +2,34 @@ import { FixedNumber } from "ethers";
 import { FIXED_NUMBER_100 } from "../constants";
 import { Fee } from "../types";
 
+const _expandExponentialNumberString = (value: string): string => {
+  const trimmed = value.trim();
+  if (!/[eE]/.test(trimmed)) {
+    return trimmed;
+  }
+
+  const match = trimmed.match(/^([+-]?)(\d+(?:\.\d+)?)[eE]([+-]?\d+)$/);
+  if (!match) {
+    return trimmed;
+  }
+
+  const sign = match[1] ?? "";
+  const coefficient = match[2];
+  const exponent = parseInt(match[3], 10);
+
+  const [integerPart, fractionalPart = ""] = coefficient.split(".");
+  const digits = `${integerPart}${fractionalPart}`;
+  const decimalIndex = integerPart.length + exponent;
+
+  if (decimalIndex <= 0) {
+    return `${sign}0.${"0".repeat(-decimalIndex)}${digits}`;
+  }
+  if (decimalIndex >= digits.length) {
+    return `${sign}${digits}${"0".repeat(decimalIndex - digits.length)}`;
+  }
+  return `${sign}${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`;
+};
+
 /**
  * Sums up the basis points for fees.
  * @param fees The fees to sum up
@@ -22,8 +50,9 @@ export const totalBasisPointsForFees = (fees: Fee[]): bigint => {
  * @returns the basis points
  */
 export const basisPointsForFee = (fee: Fee): bigint => {
+  const feeString = _expandExponentialNumberString(fee.fee.toString());
   return BigInt(
-    FixedNumber.fromString(fee.fee.toString())
+    FixedNumber.fromString(feeString)
       .mul(FIXED_NUMBER_100)
       .toFormat(0) // format to 0 decimal places to convert to bigint
       .toString(),

--- a/test/utils/fees.spec.ts
+++ b/test/utils/fees.spec.ts
@@ -70,6 +70,15 @@ suite("Utils: fees", () => {
       };
       expect(basisPointsForFee(fee)).to.equal(1n);
     });
+
+    test("handles scientific notation percentages", () => {
+      const fee: Fee = {
+        fee: 1e-7,
+        recipient: "0x0000000000000000000000000000000000000000",
+        required: false,
+      };
+      expect(basisPointsForFee(fee)).to.equal(0n);
+    });
   });
 
   suite("totalBasisPointsForFees", () => {


### PR DESCRIPTION
## Motivation

_basisPointsForFee_ relied on FixedNumber.fromString(fee.fee.toString()). 

For very small JS numbers, toString() may produce scientific notation (e.g. 1e-7), which can cause FixedNumber.fromString to throw.

## Solution

Expand exponential number strings into standard decimal strings before parsing. **Add a unit test** covering scientific-notation input.