### PR TITLE
fix(orders): Fix orders query pagination when cursor is empty

### DIFF
--- a/src/orders/utils.ts
+++ b/src/orders/utils.ts
@@ -193,9 +193,10 @@ type OrdersQueryPathOptions = "protocol" | "side";
 export const serializeOrdersQueryOptions = (
   options: Omit<OrdersQueryOptions, OrdersQueryPathOptions>,
 ) => {
+  const normalizedCursor = options.cursor?.trim();
   return {
     limit: options.limit,
-    cursor: options.cursor ?? options.next,
+    cursor: normalizedCursor ? normalizedCursor : options.next,
 
     payment_token_address: options.paymentTokenAddress,
     maker: options.maker,

--- a/test/orders/utils.spec.ts
+++ b/test/orders/utils.spec.ts
@@ -89,6 +89,14 @@ suite("Orders: utils", () => {
       expect(result.cursor).to.equal("next456");
     });
 
+    test("should use next when cursor is empty string", () => {
+      const result = serializeOrdersQueryOptions({
+        cursor: "",
+        next: "next456",
+      });
+      expect(result.cursor).to.equal("next456");
+    });
+
     test("should handle empty tokenIds array", () => {
       const result = serializeOrdersQueryOptions({
         tokenIds: [],


### PR DESCRIPTION
## Motivation 

_serializeOrdersQueryOptions_ used nullish coalescing for cursor, which treats an empty string as a valid cursor. This can send cursor= and break pagination when next is available.

## Solution
Trim and validate cursor; if it’s empty, fall back to next. **Add a unit test covering the empty-cursor case.**