### PR TITLE
docs(api): clarify post() parameter is headers, not connection options

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -717,18 +717,18 @@ export class OpenSeaAPI {
    * Generic post method for any API endpoint with automatic rate limit retry
    * @param apiPath Path to URL endpoint under API
    * @param body Data to send.
-   * @param opts ethers ConnectionInfo, similar to Fetch API.
+   * @param headers Additional headers to send with the request.
    * @returns @typeParam T The response from the API.
    */
   public async post<T>(
     apiPath: string,
     body?: object,
-    opts?: object,
+    headers?: object,
   ): Promise<T> {
     return executeWithRateLimit(
       async () => {
         const url = `${this.apiBaseUrl}${apiPath}`;
-        return await this._fetch(url, opts, body);
+        return await this._fetch(url, headers, body);
       },
       { logger: this.logger },
     );
@@ -749,8 +749,9 @@ export class OpenSeaAPI {
   }
 
   /**
-   * Get from an API Endpoint, sending auth token in headers
-   * @param opts ethers ConnectionInfo, similar to Fetch API
+   * Fetch from an API Endpoint, sending auth token in headers
+   * @param url The URL to fetch
+   * @param headers Additional headers to send with the request
    * @param body Optional body to send. If set, will POST, otherwise GET
    */
   private async _fetch(url: string, headers?: object, body?: object) {

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -15,8 +15,8 @@ export interface Fetcher {
    * Generic post method for POST requests with automatic rate limit retry
    * @param apiPath Path to URL endpoint under API
    * @param body Data to send.
-   * @param opts Optional connection options.
+   * @param headers Additional headers to send with the request.
    * @returns The response from the API.
    */
-  post<T>(apiPath: string, body?: object, opts?: object): Promise<T>;
+  post<T>(apiPath: string, body?: object, headers?: object): Promise<T>;
 }


### PR DESCRIPTION
## Summary

- Renamed `opts` parameter to `headers` in `post()` method and `Fetcher` interface
- Updated JSDoc to accurately describe the parameter as "additional headers" instead of "ethers ConnectionInfo"

This is a documentation-only change that clarifies the actual behavior. The implementation has always treated this parameter as headers, but the docs incorrectly suggested it was a ConnectionInfo-like options object.

Related to #1868 - this is a simpler fix that documents the existing behavior rather than adding complexity to support both patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)