### PR TITLE
fix(api): serialize falsy query params

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -738,10 +738,14 @@ export class OpenSeaAPI {
     const urlSearchParams = new URLSearchParams();
 
     Object.entries(params).forEach(([key, value]) => {
-      if (value && Array.isArray(value)) {
-        value.forEach((item) => item && urlSearchParams.append(key, item));
-      } else if (value) {
-        urlSearchParams.append(key, value);
+      if (value !== undefined && value !== null && Array.isArray(value)) {
+        value.forEach((item) => {
+          if (item !== undefined && item !== null) {
+            urlSearchParams.append(key, String(item));
+          }
+        });
+      } else if (value !== undefined && value !== null) {
+        urlSearchParams.append(key, String(value));
       }
     });
 

--- a/test/api/api.spec.ts
+++ b/test/api/api.spec.ts
@@ -106,6 +106,28 @@ suite("API", () => {
     assert.equal(result.address, "0x0000000000000000000000000000000000000000");
   });
 
+  test("API get serializes falsy query params", async () => {
+    const successResponse = {
+      address: "0x0000000000000000000000000000000000000000",
+      decimals: 18,
+      eth_price: "1",
+      name: "Ether",
+      symbol: "ETH",
+      usd_price: "1800",
+    };
+
+    fetchStub = sinon
+      .stub(api as unknown as { _fetch: () => Promise<unknown> }, "_fetch")
+      .resolves(successResponse);
+
+    await api.get("/api/v2/test", { limit: 0, include: false });
+
+    assert.equal(fetchStub.callCount, 1);
+    const url = fetchStub.firstCall.args[0] as string;
+    assert.include(url, "limit=0");
+    assert.include(url, "include=false");
+  });
+
   test("API parses Retry-After HTTP-date header", () => {
     // Pin system time for deterministic date math
     clock.setSystemTime(new Date("2020-01-01T00:00:00.000Z"));


### PR DESCRIPTION
## Motivation

Query parameter serialization should not drop valid falsy values such as `0` or `false`. The previous implementation could omit these values when building `URLSearchParams`, leading to incorrect requests (e.g. `limit=0` or boolean flags not being sent).

## Solution

- Updated serialize all values except `null` and `undefined` (including `0`, `false`, and empty strings).
- Preserved array handling while ensuring array items also skip only `null`/`undefined`.
- Added a unit test: verifies the generated request URL includes `limit=0` and `include=false`.