### PR TITLE
Fix FAQ table of contents heading mismatch

### DIFF
--- a/developerDocs/faq.md
+++ b/developerDocs/faq.md
@@ -9,7 +9,7 @@ hidden: false
 
 - [How do I access the source code?](#how-do-i-access-the-source-code)
 - [What chains are supported?](#what-chains-are-supported)
-- [There is no SDK method for the API request I am trying to call.](#there-is-no-sdk-method-for-the-api-request-i-am-trying-to-call)
+- [Why is there no SDK method for the API request I am trying to call?](#why-is-there-no-sdk-method-for-the-api-request-i-am-trying-to-call)
 
 ## How do I access the source code?
 


### PR DESCRIPTION
## Motivation

The table of contents link in the FAQ documentation did not match the actual section heading, causing potential confusion and broken anchor links.

## Solution

Updated the TOC entry from:
- "There is no SDK method for the API request I am trying to call."

To match the actual heading:
- "Why is there no SDK method for the API request I am trying to call?"

This ensures the TOC accurately reflects the section headings and that anchor links work correctly.