### PR TITLE
Fix grammar in TransactionConfirmed JSDoc comment

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export enum EventType {
    */
   TransactionCreated = "TransactionCreated",
   /**
-   * Emitted when the transaction has succeeded is mined and confirmed.
+   * Emitted when the transaction is mined and confirmed.
    */
   TransactionConfirmed = "TransactionConfirmed",
   /**


### PR DESCRIPTION
## Motivation

The JSDoc comment for the TransactionConfirmed event type contained a grammatical error.

## Solution

Changed from Emitted when the transaction has succeeded is mined and confirmed to Emitted when the transaction is mined and confirmed.

The original sentence had an awkward phrase has succeeded is mined which was grammatically incorrect.