### PR TITLE
Fix typo: this methods -> this method in approveOrder JSDoc

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -808,7 +808,7 @@ export class OpenSeaSDK {
   }
 
   /**
-   * Instead of signing an off-chain order, this methods allows you to approve an order
+   * Instead of signing an off-chain order, this method allows you to approve an order
    * with an on-chain transaction.
    * @param order Order to approve
    * @param domain An optional domain to be hashed and included at the end of fulfillment calldata.  This can be used for on-chain order attribution to assist with analytics.

--- a/src/sdk/fulfillment.ts
+++ b/src/sdk/fulfillment.ts
@@ -289,7 +289,7 @@ export class FulfillmentManager {
   }
 
   /**
-   * Instead of signing an off-chain order, this methods allows you to approve an order
+   * Instead of signing an off-chain order, this method allows you to approve an order
    * with an on-chain transaction.
    * @param order Order to approve
    * @param domain An optional domain to be hashed and included at the end of fulfillment calldata.  This can be used for on-chain order attribution to assist with analytics.


### PR DESCRIPTION
## Motivation

The JSDoc comment for the approveOrder method contained a grammatical error in both sdk.ts and sdk/fulfillment.ts.

## Solution

Changed this methods allows to this method allows in the approveOrder method documentation.