### PR TITLE
docs: add API key security note to API reference

### DIFF
--- a/developerDocs/api-reference.md
+++ b/developerDocs/api-reference.md
@@ -11,6 +11,8 @@ hidden: false
 
 This comprehensive reference documents all OpenSea API endpoints available through the opensea-js SDK. The SDK provides convenient TypeScript methods to interact with the OpenSea API v2.
 
+> **Note:** Your API key should only be used on a secure backend server. Never expose it in client-side code, public repositories, or browser environments. See the [Security Warning](../README.md#security-warning) in the README for more details.
+
 - [NFT Endpoints](#nft-endpoints)
 - [Collection Endpoints](#collection-endpoints)
 - [Listing Endpoints](#listing-endpoints)


### PR DESCRIPTION
## Summary
Adds a brief security note at the top of the API reference reminding developers to keep their API key on a secure backend server, with a link to the README's Security Warning section.

Closes #1883

## Test plan
- [x] Documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)