### PR TITLE
fix(orders): fall back to tokenId when tokenIds is empty

### DIFF
--- a/src/orders/utils.ts
+++ b/src/orders/utils.ts
@@ -203,6 +203,13 @@ type OrdersQueryPathOptions = "protocol" | "side";
 export const serializeOrdersQueryOptions = (
   options: Omit<OrdersQueryOptions, OrdersQueryPathOptions>,
 ) => {
+  const tokenIds =
+    options.tokenIds && options.tokenIds.length > 0
+      ? options.tokenIds
+      : options.tokenId !== undefined
+        ? [options.tokenId]
+        : options.tokenIds;
+
   return {
     limit: options.limit,
     cursor: options.cursor ?? options.next,
@@ -213,9 +220,7 @@ export const serializeOrdersQueryOptions = (
     owner: options.owner,
     listed_after: options.listedAfter,
     listed_before: options.listedBefore,
-    token_ids:
-      options.tokenIds ??
-      (options.tokenId !== undefined ? [options.tokenId] : undefined),
+    token_ids: tokenIds,
     asset_contract_address: options.assetContractAddress,
     order_by: options.orderBy,
     order_direction: options.orderDirection,

--- a/test/orders/utils.spec.ts
+++ b/test/orders/utils.spec.ts
@@ -95,6 +95,14 @@ suite("Orders: utils", () => {
       });
       expect(result.token_ids).to.deep.equal([]);
     });
+
+    test("should fall back to tokenId when tokenIds is empty", () => {
+      const result = serializeOrdersQueryOptions({
+        tokenId: "123",
+        tokenIds: [],
+      });
+      expect(result.token_ids).to.deep.equal(["123"]);
+    });
   });
 
   suite("getFulfillmentDataPath", () => {


### PR DESCRIPTION
## Summary

- fall back to `tokenId` when `tokenIds` is an empty array in `serializeOrdersQueryOptions`
- add a regression test for the `tokenIds: []` + `tokenId` case

## Why

When both `tokenIds: []` and `tokenId` are provided, the serializer currently prefers the empty `tokenIds` array and drops the token filter entirely from the request.

That creates a mismatch with the surrounding validation logic and can send an unfiltered orders request even though a specific `tokenId` was provided.

## Testing

- added a unit test for the empty `tokenIds` fallback case

