### PR TITLE
fix(cancelOrders): reject orders that span different protocol addresses

### DIFF
--- a/src/sdk/cancellation.ts
+++ b/src/sdk/cancellation.ts
@@ -167,6 +167,23 @@ export class CancellationManager {
       throw new Error("At least one order hash must be provided")
     }
 
+    // Cancellation is a single transaction to one Seaport contract, so every
+    // order must live on the same protocol. Mixing protocol addresses would
+    // send the others to the wrong contract and silently leave them live.
+    if (orders) {
+      const protocols = new Set(
+        orders
+          .filter(order => "protocolData" in order)
+          .map(order => (order as OrderV2).protocolAddress.toLowerCase()),
+      )
+      if (protocols.size > 1) {
+        throw new Error(
+          "All orders must use the same protocolAddress to be cancelled in one call. " +
+            "Cancel orders from different protocols separately.",
+        )
+      }
+    }
+
     requireValidProtocol(protocolAddress)
 
     // Check account availability after parameter validation

--- a/test/sdk/cancelOrders.spec.ts
+++ b/test/sdk/cancelOrders.spec.ts
@@ -1,6 +1,7 @@
 import type { OrderComponents } from "@opensea/seaport-js/lib/types"
 import { ethers } from "ethers"
 import { describe, expect, test } from "vitest"
+import { ALTERNATE_SEAPORT_V1_6_ADDRESS } from "../../src/constants"
 import type { OrderV2 } from "../../src/orders/types"
 import { DEFAULT_SEAPORT_CONTRACT_ADDRESS } from "../../src/orders/utils"
 import { sdk } from "../utils/sdk"
@@ -81,6 +82,43 @@ describe("SDK: cancelOrders", () => {
       expect((e as Error).message).toContain(
         "Cannot provide both orders and orderHashes",
       )
+    }
+  })
+
+  test("Should throw when orders span different protocol addresses", async () => {
+    const mockOrderComponents: OrderComponents = {
+      offerer: "0x0000000000000000000000000000000000000001",
+      zone: "0x0000000000000000000000000000000000000000",
+      offer: [],
+      consideration: [],
+      orderType: 0,
+      startTime: "0",
+      endTime: "0",
+      zoneHash:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      salt: "0",
+      conduitKey:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      totalOriginalConsiderationItems: 0,
+      counter: 0,
+    }
+    const makeOrderV2 = (protocolAddress: string) =>
+      ({
+        protocolData: { parameters: mockOrderComponents },
+        protocolAddress,
+      }) as unknown as OrderV2
+
+    try {
+      await sdk.cancelOrders({
+        orders: [
+          makeOrderV2(DEFAULT_SEAPORT_CONTRACT_ADDRESS),
+          makeOrderV2(ALTERNATE_SEAPORT_V1_6_ADDRESS),
+        ],
+        accountAddress,
+      })
+      throw new Error("should have thrown")
+    } catch (e) {
+      expect((e as Error).message).toContain("same protocolAddress")
     }
   })
 


### PR DESCRIPTION
## What

`cancelOrders` rejects a batch of orders that span more than one Seaport protocol address, instead of silently cancelling only one protocol's orders.

## Why

`cancelOrders` builds a single transaction to one Seaport contract, but it derives the target protocol with a last-write-wins loop over the orders:

```ts
let effectiveProtocolAddress = protocolAddress
orderComponents = orders.map(order => {
  if ("protocolData" in order) {
    requireValidProtocol(orderV2.protocolAddress)
    effectiveProtocolAddress = orderV2.protocolAddress // overwritten each iteration
    ...
```

There are two valid protocol addresses (`CROSS_CHAIN_SEAPORT_V1_6_ADDRESS` and `ALTERNATE_SEAPORT_V1_6_ADDRESS` in `VALID_PROTOCOL_ADDRESSES`), so a batch that mixes them passes `requireValidProtocol` for every order. `effectiveProtocolAddress` ends as the last order's protocol, and the single cancel transaction goes to that one contract with all of the order components. The orders that belong to the other protocol are sent to the wrong contract and are not cancelled, so they remain live and fillable, while the caller believes every order in the batch was cancelled.

## Change

Before building the transaction, reject when the provided orders span more than one protocol address, with a message telling the caller to cancel each protocol separately. The check runs with the other up-front input validation so it fails fast.

## Tests

Adds a regression test (`test/sdk/cancelOrders.spec.ts`). Against the current code it fails (the mixed-protocol batch is not rejected; it falls through to the account check):

```
AssertionError: expected 'Specified accountAddress is not avail...' to contain 'same protocolAddress'
```

With the fix it passes (the batch is rejected up front). `tsc --noEmit` and `biome check` are clean on the changed files.
