### PR TITLE
test: make all-chain collections coverage opt-in

### DIFF
--- a/test/integration/getCollection.spec.ts
+++ b/test/integration/getCollection.spec.ts
@@ -4,6 +4,10 @@ import { Chain, SafelistStatus } from "../../src/types"
 import { getSdkForChain } from "../utils/setupIntegration"
 import { processInBatches } from "../utils/utils"
 
+const runAllChainCollections =
+  process.env.OPENSEA_RUN_ALL_CHAIN_COLLECTIONS === "true"
+const allChainCollectionsTest = runAllChainCollections ? test : test.skip
+
 describe("SDK: getCollection", () => {
   test("Get Verified Collection", async () => {
     const slug = "cool-cats-nft"
@@ -69,7 +73,7 @@ describe("SDK: getCollection", () => {
     expect(stats.intervals, "Intervals should exist").toBeTruthy()
   })
 
-  test.skip("Get Collections for all chains", async () => {
+  allChainCollectionsTest("Get Collections for all chains", async () => {
     // Excluding Solana (no NFT collections)
     const chains = Object.values(Chain).filter(chain => chain !== Chain.Solana)
     const sdk = getSdkForChain(Chain.Mainnet)


### PR DESCRIPTION
Closes #1986.

## What changed

- Replace the unconditional skip on the all-chain `getCollections` integration test with an explicit `OPENSEA_RUN_ALL_CHAIN_COLLECTIONS=true` gate.

## Why

The test remains disabled by default for normal integration runs, but it is no longer permanently unreachable. Maintainers can enable the broader chain coverage in scheduled/manual CI or when validating multi-chain API behavior.

## Testing

- `git diff --check`
- `npm run test -- --run test/integration/getCollection.spec.ts` could not run because dependencies are not installed locally (`vitest` not found).
