### PR TITLE
Fix linkWallet corrupting the camelCase SIWX wallet-link body

### DIFF
--- a/src/api/walletAuth.ts
+++ b/src/api/walletAuth.ts
@@ -400,11 +400,20 @@ export class WalletAuthAPI {
     )
   }
 
+  /**
+   * `LinkWalletSiwxRequest` is camelCase on the wire: `chainArch` is required,
+   * and the nested SIWX `message` keeps camelCase keys (`chainId`, `issuedAt`)
+   * that the server uses to rebuild the message the wallet signed. Snake-casing
+   * the body made this call fail validation every time. Sent verbatim, matching
+   * the raw fetch in `auth/siwx.ts` that posts the same operation.
+   */
   linkWallet(body: WalletAuthRequest<"link_wallet_with_siwx">) {
     return this.fetcher.request<OperationResponse<"link_wallet_with_siwx">>(
       "POST",
       "/api/v2/accounts/wallets/siwx",
       body,
+      undefined,
+      { snakeizeBody: false },
     )
   }
 

--- a/test/api/walletAuthCasing.spec.ts
+++ b/test/api/walletAuthCasing.spec.ts
@@ -55,10 +55,12 @@ const KNOWN_CAMELCASE_OPERATIONS = [
   "post_criteria_offer_v2",
   "post_listing",
   "post_offer",
-  // Sent by auth/siwx.ts via raw fetch + JSON.stringify, so never snake_cased.
-  "link_wallet_with_siwx",
   // WalletAuthAPI — opted out below, covered by the behavioural tests here.
+  // `link_wallet_with_siwx` is also posted by auth/siwx.ts via raw fetch +
+  // JSON.stringify, which never snake_cases; the WalletAuthAPI path needs the
+  // explicit opt-out to match it.
   "cancel_order",
+  "link_wallet_with_siwx",
   "set_profile_nft_pfp",
   "update_profile_settings",
   "upload_profile_image",
@@ -182,6 +184,24 @@ describe("wallet-auth request body casing", () => {
     const call = request.mock.calls[0]
     expect(optionsOf(call)?.snakeizeBody).toBe(false)
     expect(bodyOf(call)).toMatchObject({ offererSignature: "0xsig" })
+  })
+
+  it("sends link_wallet_with_siwx verbatim so chainArch and the signed message survive", async () => {
+    // chainArch is required, so snake-casing it made the call fail validation.
+    // The nested message keys are camelCase too, and the server rebuilds the
+    // signed SIWX message from them — renaming them breaks verification.
+    await api.linkWallet({
+      chainArch: "EVM",
+      signature: "0xsig",
+      message: { chainId: "1", issuedAt: "2026-01-01T00:00:00Z" },
+    } as never)
+
+    const call = request.mock.calls[0]
+    expect(optionsOf(call)?.snakeizeBody).toBe(false)
+    expect(bodyOf(call)).toMatchObject({
+      chainArch: "EVM",
+      message: { chainId: "1", issuedAt: "2026-01-01T00:00:00Z" },
+    })
   })
 
   it("leaves snake_case bodies on the default path", async () => {


### PR DESCRIPTION
`f67fbc6` (11.7.1) fixed camelCase request bodies for four wallet-auth endpoints and added `test/api/walletAuthCasing.spec.ts` as a tripwire so the bug class wouldn't come back. A fifth call site for the same operation was missed.

### The bug

`WalletAuthAPI.linkWallet` (`src/api/walletAuth.ts`) posts `link_wallet_with_siwx` through `Fetcher.request`, which snake_cases every body unless told otherwise.

`LinkWalletSiwxRequest` is camelCase on the wire: `message`, `signature`, `chainArch`. Because `chainArch` is required, snake-casing turned it into `chain_arch` and the request failed validation — the same failure mode as `setProfileNftPfp` and `createProfileImageUpload` in `f67fbc6`, where the call can never succeed rather than silently losing a field. The nested SIWX `message` object also carries camelCase keys (`chainId`, `issuedAt`, `expirationTime`) that the server uses to rebuild the message the wallet signed, so those were being renamed as well.

### Why the tripwire didn't catch it

`link_wallet_with_siwx` was already in `KNOWN_CAMELCASE_OPERATIONS`, but annotated as safe:

```ts
// Sent by auth/siwx.ts via raw fetch + JSON.stringify, so never snake_cased.
"link_wallet_with_siwx",
```

That is accurate for `auth/siwx.ts`, which posts the operation with a raw `fetch` + `JSON.stringify` and never touches `Fetcher`. It is not accurate for the `WalletAuthAPI.linkWallet` path, which does. The note described one call site and, by satisfying the tripwire, concealed the other.

### The fix

```diff
   linkWallet(body: WalletAuthRequest<"link_wallet_with_siwx">) {
     return this.fetcher.request<OperationResponse<"link_wallet_with_siwx">>(
       "POST",
       "/api/v2/accounts/wallets/siwx",
       body,
+      undefined,
+      { snakeizeBody: false },
     )
   }
```

Same opt-out as the four endpoints in `f67fbc6`, so both code paths now put an identical payload on the wire.

### Tests

- Added a behavioural test next to the existing four, asserting `snakeizeBody: false` and that `chainArch` plus the nested `message` keys survive.
- Confirmed the test is a real tripwire and not a vacuous one: with the fix reverted it fails with `expected false, received undefined`.
- Moved the `link_wallet_with_siwx` entry into the WalletAuthAPI group and rewrote the comment so it documents both call sites. The list is sorted before comparison, so the spec-derived equality check is unaffected and still passes.
- `npm run check-types` and Biome are clean on both files.

### A note for maintainers

I understand this repo is a read-only mirror and that the change would be recreated internally — happy for it to be handled that way. The one-line behavioural difference is `snakeizeBody: false` on `linkWallet`; everything else is the test.