### PR TITLE
fix(getTraits): stop camelizing collection-authored trait keys

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1402,7 +1402,7 @@ export class OpenSeaAPI {
           ? `${this.apiBaseUrl}${apiPath}?${qs}`
           : `${this.apiBaseUrl}${apiPath}`
         const raw = await this._fetch(url, "GET", undefined, undefined, options)
-        return camelizeKeysDeep(raw) as Camelize<T>
+        return this.camelizeResponseBody<T>(raw, options)
       },
       { logger: this.logger },
     )
@@ -1447,10 +1447,24 @@ export class OpenSeaAPI {
         const wireBody =
           body == null || !shouldSnakeize ? body : snakeizeKeysDeep(body)
         const raw = await this._fetch(url, method, headers, wireBody, options)
-        return camelizeKeysDeep(raw) as Camelize<T>
+        return this.camelizeResponseBody<T>(raw, options)
       },
       { logger: this.logger },
     )
+  }
+
+  /**
+   * Camelize a response body unless the caller opted out via
+   * {@link RequestOptions.camelizeResponse}, which endpoints keyed by data
+   * rather than field names (e.g. traits) rely on to keep their keys intact.
+   */
+  private camelizeResponseBody<T>(
+    raw: unknown,
+    options?: RequestOptions,
+  ): Camelize<T> {
+    return options?.camelizeResponse === false
+      ? (raw as Camelize<T>)
+      : (camelizeKeysDeep(raw) as Camelize<T>)
   }
 
   private objectToSearchParams(params: object = {}) {

--- a/src/api/collections.ts
+++ b/src/api/collections.ts
@@ -79,10 +79,20 @@ export class CollectionsAPI {
 
   /**
    * Fetch all traits for a collection with their possible values and counts.
+   *
+   * Opts out of response camelization: this payload is keyed by
+   * collection-authored trait names and trait values rather than by field
+   * names, so the default rewrite reports a `dark_brown` trait as `darkBrown`
+   * and merges two traits that differ only in casing. The response's own field
+   * names (`categories`, `counts`) are single words with nothing to convert.
    */
   async getTraits(collectionSlug: string): Promise<GetTraitsResponse> {
     const path = getTraitsPath(collectionSlug)
-    const response = await this.fetcher.get<GetTraitsResponse>(path)
+    const response = await this.fetcher.get<GetTraitsResponse>(
+      path,
+      undefined,
+      { camelizeResponse: false },
+    )
     return response
   }
 

--- a/src/api/fetcher.ts
+++ b/src/api/fetcher.ts
@@ -33,14 +33,17 @@ export type HttpMethod = "POST" | "PUT" | "PATCH" | "DELETE"
  *
  * Responses are camelized at this boundary — pass the API's snake_case shape
  * (e.g. an api-types response type) as `T` and the return is the camelCase
- * view. See `utils/case.ts`.
+ * view. See `utils/case.ts`. Endpoints whose response keys are data rather
+ * than field names opt out with {@link RequestOptions.camelizeResponse}.
  */
 export interface Fetcher {
   /**
    * Generic fetch method for GET requests with automatic rate limit retry
    * @param apiPath Path to URL endpoint under API
    * @param query URL query params. Will be used to create a URLSearchParams object.
-   * @param options Request options like timeout and abort signal.
+   * @param options Request options like timeout and abort signal. Includes the
+   *                {@link RequestOptions.camelizeResponse} opt-out for endpoints
+   *                whose response keys are data (e.g. trait names).
    * @returns The camelCase view of the API response.
    */
   get<T>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -328,4 +328,16 @@ export interface RequestOptions {
    * await api.post('/path', body, headers, { signal: controller.signal });
    */
   signal?: AbortSignal
+  /**
+   * Whether to recursively rewrite the response's keys from snake_case to
+   * camelCase. Defaults to `true`.
+   *
+   * Set to `false` for endpoints whose response keys are data rather than
+   * field names. `getTraits` returns objects keyed by collection-authored
+   * trait names and trait values, so the default rewrite reports a
+   * `dark_brown` trait as `darkBrown` and merges two traits that differ only
+   * in casing. The caller is then responsible for passing a `T` that already
+   * matches the wire shape.
+   */
+  camelizeResponse?: boolean
 }

--- a/test/api/api.spec.ts
+++ b/test/api/api.spec.ts
@@ -64,6 +64,29 @@ describe("API", () => {
     )
   })
 
+  test("getTraits keeps collection-authored trait keys intact", async () => {
+    // The traits payload is keyed by trait name and trait value, not by field
+    // name. Camelizing it renames `fur_color` to `furColor`, and the two
+    // distinct values below collapse into a single `darkBrown` entry whose
+    // count is wrong — a silent data loss the caller cannot detect.
+    vi.useRealTimers()
+    fetchStub = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          categories: { fur_color: "string" },
+          counts: { fur_color: { dark_brown: 12, darkBrown: 3 } },
+        }),
+        { status: 200 },
+      ),
+    )
+    const localApi = new OpenSeaAPI({ apiKey: "key" })
+
+    const traits = await localApi.getTraits("doodles-official")
+
+    expect(traits.categories).toEqual({ fur_color: "string" })
+    expect(traits.counts.fur_color).toEqual({ dark_brown: 12, darkBrown: 3 })
+  })
+
   test("request accepts empty successful responses", async () => {
     vi.useRealTimers()
     fetchStub = vi

--- a/test/api/collections.spec.ts
+++ b/test/api/collections.spec.ts
@@ -452,6 +452,16 @@ describe("API: CollectionsAPI", () => {
       expect(result.counts.Fur["Golden Brown"]).toBe(456)
     })
 
+    test("opts out of response camelization", async () => {
+      // The keys in this payload are trait names and trait values, so the
+      // fetcher's default snake_case → camelCase rewrite would corrupt them.
+      mockGet.mockResolvedValue({ categories: {}, counts: {} })
+
+      await collectionsAPI.getTraits("boredapeyachtclub")
+
+      expect(mockGet.mock.calls[0][2]).toEqual({ camelizeResponse: false })
+    })
+
     test("handles collection with no traits", async () => {
       const mockResponse: GetTraitsResponse = {
         categories: {},


### PR DESCRIPTION
`getTraits` returns objects keyed by trait names and trait values, but `Fetcher` camelizes every response body. A collection with a `fur_color` trait gets reported as `furColor`, and its `dark_brown` value as `darkBrown`.

Given this response:

```json
{
  "categories": { "fur_color": "string" },
  "counts": { "fur_color": { "dark_brown": 12, "darkBrown": 3 } }
}
```

the SDK currently returns `counts.furColor` as `{ "darkBrown": 3 }`. The rename alone breaks any lookup by trait name, but the two distinct values also collide into a single key — one trait silently disappears and the surviving count is wrong. Nothing in the response tells the caller this happened.

### Why this is a v11 regression

Response camelization is applied to every endpoint by `e7deba3` in 11.0.0:

> Rebuild the SDK's type layer on `@opensea/api-types` with automatic case translation at the fetcher boundary. […] the fetcher snakeizes outgoing query params and POST bodies and camelizes responses, so the SDK no longer ships hand-rolled response shapes.

That assumption — response keys are field names, so rewriting them is safe — holds for every spec-derived response. `getTraits` predates the change and is the one endpoint it doesn't hold for: the OpenAPI spec has no schema for `/api/v2/traits/{slug}`, only an example, whose keys are the collection's own trait names (`face`, `background`, `level`). Because there was no generated type to migrate to, `GetTraitsResponse` stayed hand-written in `src/api/types.ts` as a pair of index signatures — while the blanket camelizer was applied to it along with everything else.

Before v11 there was no camelization in `src/api/api.ts` at all; conversion was per-endpoint in `utils/converters.ts`, which this endpoint never opted into. So this looks like collateral damage of the migration rather than an intentional choice.

### Why the tests didn't catch it

Every existing `getTraits` test mocks the fetcher (`mockGet.mockResolvedValue(...)`), so the camelization step never runs in the suite. The fixtures also happen to use casing-free names like `Background` and `Golden Brown`. One of them is already affected in principle — `"Special-Character_123"` would come back as `"Special-Character123"` through the real pipeline — but the mock means it never gets there.

### The fix

Adds `camelizeResponse` to `RequestOptions`, mirroring the existing `snakeizeBody` opt-out for request bodies, and sets it to `false` for `getTraits`:

```ts
const response = await this.fetcher.get<GetTraitsResponse>(
  path,
  undefined,
  { camelizeResponse: false },
)
```

Both `get` and `request` honour it, so the option doesn't silently do nothing on writes. Opting out is complete for this endpoint rather than a partial workaround: the response's own field names (`categories`, `counts`, and `min`/`max` for numeric traits) are single words with nothing to convert, so everything left is data that must survive verbatim. `GetTraitsResponse` is unaffected at the type level, since `Camelize<T>` passes index signatures through unchanged.

Scope is one endpoint — `GetTraitsResponse` is the only response type in `src/api/types.ts` keyed by data rather than by field names.

### Tests

- End-to-end test in `test/api/api.spec.ts` that stubs `fetch` and asserts both trait names and trait values survive, including the two values that otherwise collide.
- Confirmed it is a real tripwire: with the fix reverted it fails with `expected { furColor: 'string' } to deeply equal { fur_color: 'string' }`.
- Call-site test in `test/api/collections.spec.ts` asserting the opt-out is passed, so a future refactor of `getTraits` can't quietly drop it.
- Full suite green (794 tests), `npm run check-types` and Biome clean.
