### PR TITLE
fix(utils): handle string scientific notation in parseUnits

### DIFF
--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -10,11 +10,14 @@ export function parseUnits(
 ): bigint {
   let str = value.toString()
 
-  // Handle JavaScript scientific notation (e.g. 1e-8 → "0.00000001").
+  // Handle scientific notation (e.g. 1e-8 or "1e-8" → "0.00000001").
   // Note: toFixed has precision limits for very large numbers, but this is
   // sufficient for realistic token amounts (up to ~2^53).
-  if (typeof value === "number" && str.includes("e")) {
-    str = value.toFixed(decimals)
+  if (str.toLowerCase().includes("e")) {
+    const num = Number(value)
+    if (!Number.isNaN(num)) {
+      str = num.toFixed(decimals)
+    }
   }
 
   // Handle negative values

--- a/test/utils/units.spec.ts
+++ b/test/utils/units.spec.ts
@@ -48,6 +48,12 @@ describe("parseUnits", () => {
     expect(parseUnits(1e-8, 18)).toBe(10000000000n)
   })
 
+  test("handles string scientific notation", () => {
+    expect(parseUnits("1e-8", 18)).toBe(10000000000n)
+    expect(parseUnits("1.5e-5", 18)).toBe(15000000000000n)
+    expect(parseUnits("1E-6", 6)).toBe(1n)
+  })
+
   test("throws for invalid decimal (multiple dots)", () => {
     expect(() => parseUnits("1.2.3", 18)).toThrow("Invalid decimal value")
   })


### PR DESCRIPTION
## Summary

Fixes a `SyntaxError` in `parseUnits` when passing a string formatted in scientific notation (e.g. `"1e-8"`, `"1.5e-5"`, `"1E-6"`).

Previously, the scientific notation check checked `typeof value === "number" && str.includes("e")`. When `value` was passed as a string containing exponential notation (`"1e-8"`), the condition evaluated to `false`, leaving `str` as `"1e-8"`. During unit calculation, this produced `"1e-8000000000000000000"`, causing `BigInt(...)` to throw `SyntaxError: Cannot convert 1e-8000000000000000000 to a BigInt`.

## Changes

- Updated `parseUnits` in `src/utils/units.ts` to check `str.toLowerCase().includes("e")` regardless of whether `value` was passed as a `number` or `string`.
- Added unit test cases for string scientific notation in `test/utils/units.spec.ts`.

## Testing

- Confirmed test `handles string scientific notation` failed on `main` with `SyntaxError`.
- Confirmed all 792 tests across 36 test files pass cleanly (`npm test`).