### PR TITLE
fix(privateListings): reject mixed ERC20 payment tokens

### DIFF
--- a/src/orders/privateListings.ts
+++ b/src/orders/privateListings.ts
@@ -58,7 +58,11 @@ export const constructPrivateListingCounterOrder = (
       )
     }
     if (
-      !paymentItems.every(item => item.itemType === paymentItems[0].itemType)
+      !paymentItems.every(
+        item =>
+          item.itemType === paymentItems[0].itemType &&
+          item.token.toLowerCase() === paymentItems[0].token.toLowerCase(),
+      )
     ) {
       throw new Error("Not all currency items were the same for private order")
     }

--- a/test/orders/privateListings.spec.ts
+++ b/test/orders/privateListings.spec.ts
@@ -12,6 +12,10 @@ const TAKER_ADDRESS = "0x2222222222222222222222222222222222222222"
 const FEE_RECIPIENT = "0x3333333333333333333333333333333333333333"
 const NFT_CONTRACT = "0x4444444444444444444444444444444444444444"
 const WETH_ADDRESS = "0x5555555555555555555555555555555555555555"
+const TOKEN_A = "0x6666666666666666666666666666666666666666"
+const TOKEN_A_UPPERCASE = "0xABCDEF0000000000000000000000000000000000"
+const TOKEN_A_LOWERCASE = "0xabcdef0000000000000000000000000000000000"
+const TOKEN_B = "0x7777777777777777777777777777777777777777"
 
 const createMockOrder = (
   consideration: OrderWithCounter["parameters"]["consideration"],
@@ -292,6 +296,86 @@ describe("Orders: privateListings", () => {
       expect(() =>
         constructPrivateListingCounterOrder(order, TAKER_ADDRESS),
       ).toThrow("Not all currency items were the same")
+    })
+
+    test("should throw if ERC20 payment items reference different tokens", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // TOKEN_A payment to seller
+        {
+          itemType: ItemType.ERC20,
+          token: TOKEN_A,
+          identifierOrCriteria: "0",
+          startAmount: "100",
+          endAmount: "100",
+          recipient: SELLER_ADDRESS,
+        },
+        // TOKEN_B payment to fee recipient
+        {
+          itemType: ItemType.ERC20,
+          token: TOKEN_B,
+          identifierOrCriteria: "0",
+          startAmount: "20",
+          endAmount: "20",
+          recipient: FEE_RECIPIENT,
+        },
+      ])
+
+      expect(() =>
+        constructPrivateListingCounterOrder(order, TAKER_ADDRESS),
+      ).toThrow("Not all currency items were the same")
+    })
+
+    test("should not treat differently-cased identical ERC20 tokens as different currencies", () => {
+      const order = createMockOrder([
+        // NFT to taker
+        {
+          itemType: ItemType.ERC721,
+          token: NFT_CONTRACT,
+          identifierOrCriteria: "1",
+          startAmount: "1",
+          endAmount: "1",
+          recipient: TAKER_ADDRESS,
+        },
+        // TOKEN_A (all-caps hex) payment to seller
+        {
+          itemType: ItemType.ERC20,
+          token: TOKEN_A_UPPERCASE,
+          identifierOrCriteria: "0",
+          startAmount: "100",
+          endAmount: "100",
+          recipient: SELLER_ADDRESS,
+        },
+        // Same token lowercased, payment to fee recipient
+        {
+          itemType: ItemType.ERC20,
+          token: TOKEN_A_LOWERCASE,
+          identifierOrCriteria: "0",
+          startAmount: "20",
+          endAmount: "20",
+          recipient: FEE_RECIPIENT,
+        },
+      ])
+
+      const counterOrder = constructPrivateListingCounterOrder(
+        order,
+        TAKER_ADDRESS,
+      )
+
+      expect(counterOrder.parameters.offer).toHaveLength(1)
+      expect(counterOrder.parameters.offer[0].itemType).toBe(ItemType.ERC20)
+      expect(counterOrder.parameters.offer[0].token).toBe(TOKEN_A_UPPERCASE)
+      expect(counterOrder.parameters.offer[0].identifierOrCriteria).toBe("0")
+      expect(counterOrder.parameters.offer[0].startAmount).toBe("120")
+      expect(counterOrder.parameters.offer[0].endAmount).toBe("120")
     })
   })
 })


### PR DESCRIPTION
## Summary

Prevent private listing counter orders from aggregating payment items that use different ERC20 token contracts.

`constructPrivateListingCounterOrder` previously validated that all payment items were currency items and shared the same `itemType`, but did not verify that ERC20 items referenced the same token.

## Problem

When multiple ERC20 consideration items use different token contracts, the helper currently aggregates their amounts into a single counter-order offer using the token from the first payment item.

For example:

- 100 TOKEN_A
- 20 TOKEN_B

would produce a single counter-order offer for:

- 120 TOKEN_A

The resulting fulfillment is later rejected by Seaport because offer and consideration components must match on token.

## Solution

Extend the existing currency validation to also require payment items to reference the same token address before aggregation.

Token comparison is case-insensitive so differently-cased representations of the same Ethereum address remain valid.

This preserves the existing behavior for:

- multiple payment items using the same ERC20 token
- native currency payments
- zero-payment private listings
- existing mixed native/ERC20 rejection

## Testing

Added regression coverage for:

- rejecting different ERC20 token contracts
- accepting differently-cased representations of the same ERC20 token

Validation performed:

- `npx vitest run test/orders/privateListings.spec.ts`
- `npx vitest run`
- `npm run check-types`
- `npm run build`
- `git diff --check`